### PR TITLE
[BUGFIX] Add missing dependencies to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
 	],
 	"require": {
 		"php": ">= 7.1 < 8.1",
+		"ext-json": "*",
 		"eliashaeussler/cache-warmup": ">= 0.4.0 < 0.7.0",
+		"guzzlehttp/guzzle": ">= 6.3.0 < 8.0.0",
+		"guzzlehttp/psr7": ">= 1.4.0 < 3.0.0",
 		"psr/http-message": "^1.0",
 		"psr/log": "^1.0",
 		"symfony/console": ">= 4.0 < 6.0",


### PR DESCRIPTION
This PR adds missing dependencies to `composer.json`, as reported by composer-require-checker.