### PR TITLE
[TASK] Declare allowed plugins in composer.json (Composer 2.2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,12 @@
 		}
 	},
 	"config": {
+		"allow-plugins": {
+			"captainhook/plugin-composer": true,
+			"ergebnis/composer-normalize": true,
+			"typo3/class-alias-loader": true,
+			"typo3/cms-composer-installers": true
+		},
 		"bin-dir": ".Build/bin",
 		"sort-packages": true,
 		"vendor-dir": ".Build/vendor"


### PR DESCRIPTION
This PR adds all allowed plugins to `composer.json` to add support for Composer 2.2.