### PR TITLE
[TASK] Streamline locallang*.xlf files with XLIFF 1.2

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,124 +1,124 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.0">
-	<file source-language="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:warming/Resources/Private/Language/locallang.xlf" date="2022-04-21T20:54:27Z" product-name="warming">
 		<header/>
 		<body>
-			<trans-unit id="cacheWarmupToolbarItem.title">
+			<trans-unit id="cacheWarmupToolbarItem.title" resname="cacheWarmupToolbarItem.title">
 				<source>Warmup cache</source>
 			</trans-unit>
-			<trans-unit id="cacheWarmupToolbarItem.loading">
+			<trans-unit id="cacheWarmupToolbarItem.loading" resname="cacheWarmupToolbarItem.loading">
 				<source>Sites are being loaded...</source>
 			</trans-unit>
-			<trans-unit id="cacheWarmupToolbarItem.description.invalid">
+			<trans-unit id="cacheWarmupToolbarItem.description.invalid" resname="cacheWarmupToolbarItem.description.invalid">
 				<source>No XML sitemap found for this site.</source>
 			</trans-unit>
-			<trans-unit id="cacheWarmupToolbarItem.userAgent.description">
+			<trans-unit id="cacheWarmupToolbarItem.userAgent.description" resname="cacheWarmupToolbarItem.userAgent.description">
 				<source><![CDATA[A custom <code>User-Agent</code> header is used for cache warmup requests. You can copy it here to exclude the requests from your site statistics, for example.]]></source>
 			</trans-unit>
-			<trans-unit id="cacheWarmupToolbarItem.userAgent.action">
+			<trans-unit id="cacheWarmupToolbarItem.userAgent.action" resname="cacheWarmupToolbarItem.userAgent.action">
 				<source>Copy to clipboard</source>
 			</trans-unit>
 
-			<trans-unit id="toolbar.sitemap.missing">
+			<trans-unit id="toolbar.sitemap.missing" resname="toolbar.sitemap.missing">
 				<source>No XML sitemap found for this language.</source>
 			</trans-unit>
-			<trans-unit id="toolbar.sitemap.placeholder">
+			<trans-unit id="toolbar.sitemap.placeholder" resname="toolbar.sitemap.placeholder">
 				<source>Select a language</source>
 			</trans-unit>
-			<trans-unit id="toolbar.copy.successful">
+			<trans-unit id="toolbar.copy.successful" resname="toolbar.copy.successful">
 				<source>Copied</source>
 			</trans-unit>
 
-			<trans-unit id="notification.title.failed">
+			<trans-unit id="notification.title.failed" resname="notification.title.failed">
 				<source>Cache warmup failed</source>
 			</trans-unit>
-			<trans-unit id="notification.title.warning">
+			<trans-unit id="notification.title.warning" resname="notification.title.warning">
 				<source>Cache warmup finished with errors</source>
 			</trans-unit>
-			<trans-unit id="notification.title.success">
+			<trans-unit id="notification.title.success" resname="notification.title.success">
 				<source>Cache warmup successful</source>
 			</trans-unit>
-			<trans-unit id="notification.title.unknown">
+			<trans-unit id="notification.title.unknown" resname="notification.title.unknown">
 				<source>Cache warmup finished</source>
 			</trans-unit>
-			<trans-unit id="notification.message.site">
+			<trans-unit id="notification.message.site" resname="notification.message.site">
 				<source>Caches for page "%1$s [%2$d]" have been warmed up with the following result:
 
 %3$d successful, %4$d failed</source>
 			</trans-unit>
-			<trans-unit id="notification.message.page.error">
+			<trans-unit id="notification.message.page.error" resname="notification.message.page.error">
 				<source>Cache could not be warmed up for "%1$s [%2$d]".</source>
 			</trans-unit>
-			<trans-unit id="notification.message.page.success">
+			<trans-unit id="notification.message.page.success" resname="notification.message.page.success">
 				<source>Cache of page "%1$s [%2$d]" was successfully warmed up.</source>
 			</trans-unit>
-			<trans-unit id="notification.message.page.unknown">
+			<trans-unit id="notification.message.page.unknown" resname="notification.message.page.unknown">
 				<source>Warming up the cache for page "%1$s [%2$d]" ended unexpectedly.</source>
 			</trans-unit>
-			<trans-unit id="notification.aborted.title">
+			<trans-unit id="notification.aborted.title" resname="notification.aborted.title">
 				<source>Cache warmup aborted</source>
 			</trans-unit>
-			<trans-unit id="notification.aborted.message">
+			<trans-unit id="notification.aborted.message" resname="notification.aborted.message">
 				<source>The cache warmup was stopped prematurely and therefore could not be completed.</source>
 			</trans-unit>
-			<trans-unit id="notification.error.title">
+			<trans-unit id="notification.error.title" resname="notification.error.title">
 				<source>An error occurred</source>
 			</trans-unit>
-			<trans-unit id="notification.error.message">
+			<trans-unit id="notification.error.message" resname="notification.error.message">
 				<source>An error occurred while warming up caches. This could be related to an incorrect extension configuration.</source>
 			</trans-unit>
-			<trans-unit id="notification.action.showReport">
+			<trans-unit id="notification.action.showReport" resname="notification.action.showReport">
 				<source>View report</source>
 			</trans-unit>
-			<trans-unit id="notification.action.retry">
+			<trans-unit id="notification.action.retry" resname="notification.action.retry">
 				<source>Run again</source>
 			</trans-unit>
 
-			<trans-unit id="modal.report.title">
+			<trans-unit id="modal.report.title" resname="modal.report.title">
 				<source>Cache warmup report</source>
 			</trans-unit>
-			<trans-unit id="modal.report.panel.failed">
+			<trans-unit id="modal.report.panel.failed" resname="modal.report.panel.failed">
 				<source>Failed</source>
 			</trans-unit>
-			<trans-unit id="modal.report.panel.successful">
+			<trans-unit id="modal.report.panel.successful" resname="modal.report.panel.successful">
 				<source>Successful</source>
 			</trans-unit>
-			<trans-unit id="modal.report.action.view">
+			<trans-unit id="modal.report.action.view" resname="modal.report.action.view">
 				<source>View</source>
 			</trans-unit>
-			<trans-unit id="modal.report.message.total">
+			<trans-unit id="modal.report.message.total" resname="modal.report.message.total">
 				<source>Total number of crawled URLs:</source>
 			</trans-unit>
-			<trans-unit id="modal.report.message.noUrlsCrawled">
+			<trans-unit id="modal.report.message.noUrlsCrawled" resname="modal.report.message.noUrlsCrawled">
 				<source>No URLs were crawled for cache warmup.</source>
 			</trans-unit>
 
-			<trans-unit id="modal.progress.title">
+			<trans-unit id="modal.progress.title" resname="modal.progress.title">
 				<source>Cache warmup is in progress</source>
 			</trans-unit>
-			<trans-unit id="modal.progress.button.report">
+			<trans-unit id="modal.progress.button.report" resname="modal.progress.button.report">
 				<source>Show report</source>
 			</trans-unit>
-			<trans-unit id="modal.progress.button.retry">
+			<trans-unit id="modal.progress.button.retry" resname="modal.progress.button.retry">
 				<source>Run again</source>
 			</trans-unit>
-			<trans-unit id="modal.progress.button.close">
+			<trans-unit id="modal.progress.button.close" resname="modal.progress.button.close">
 				<source>Close</source>
 			</trans-unit>
-			<trans-unit id="modal.progress.failedCounter">
+			<trans-unit id="modal.progress.failedCounter" resname="modal.progress.failedCounter">
 				<source>Failed: {0}</source>
 			</trans-unit>
-			<trans-unit id="modal.progress.allCounter">
+			<trans-unit id="modal.progress.allCounter" resname="modal.progress.allCounter">
 				<source><![CDATA[Processed: <strong>{0}</strong><br>Total: <strong>{1}</strong>]]></source>
 			</trans-unit>
-			<trans-unit id="modal.progress.placeholder">
+			<trans-unit id="modal.progress.placeholder" resname="modal.progress.placeholder">
 				<source>Crawling sitemaps...</source>
 			</trans-unit>
 
-			<trans-unit id="contextMenu.item.cacheWarmup">
+			<trans-unit id="contextMenu.item.cacheWarmup" resname="contextMenu.item.cacheWarmup">
 				<source>Warmup cache for this page</source>
 			</trans-unit>
-			<trans-unit id="contextMenu.item.cacheWarmupAll">
+			<trans-unit id="contextMenu.item.cacheWarmupAll" resname="contextMenu.item.cacheWarmupAll">
 				<source>Warmup all caches</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xliff version="1.0">
-	<file source-language="en" target-language="de">
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:warming/Resources/Private/Language/locallang_db.xlf" date="2022-04-21T20:54:27Z" product-name="warming">
 		<header/>
 		<body>
-			<trans-unit id="sites.xml_sitemap_path.label">
+			<trans-unit id="sites.xml_sitemap_path.label" resname="sites.xml_sitemap_path.label">
 				<source>Path to XML sitemap</source>
 			</trans-unit>
-			<trans-unit id="sites.xml_sitemap_path.description">
+			<trans-unit id="sites.xml_sitemap_path.description" resname="sites.xml_sitemap_path.description">
 				<source>Specify the path to the XML sitemap, relative to the entry point of the site.
 Note that caches can be warmed up only if the entry point of the site contains the full domain name.</source>
 			</trans-unit>


### PR DESCRIPTION
This PR streamlines all locallang*.xlf files with the XLIFF 1.2 standard, which is currently supported by TYPO3 CMS.