### PR TITLE
[BUGFIX] Exclude generated JavaScript files from .editorconfig linting

### DIFF
--- a/.editorconfig-lint.php
+++ b/.editorconfig-lint.php
@@ -21,35 +21,11 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-return [
-    'directories' => [
-        '.build',
-        '.git',
-        '.github',
-        'bin',
-        'build',
-        'public',
-        'resources\\/private\\/frontend\\/node_modules',
-        'resources\\/private\\/libs\\/build',
-        'tailor-version-upload',
-        'tests',
-        'vendor',
-    ],
-    'files' => [
-        'DS_Store',
-        'captainhook.json',
-        'codecov.yml',
-        'composer.lock',
-        'crowdin.yaml',
-        'dependency-checker.json',
-        'editorconfig',
-        'editorconfig-lint.php',
-        'gitattributes',
-        'gitignore',
-        'packaging_exclude.php',
-        'php-cs-fixer.php',
-        'phpstan.neon',
-        'phpunit.ci.xml',
-        'phpunit.xml',
-    ],
-];
+return \Symfony\Component\Finder\Finder::create()
+    ->files()
+    ->in(__DIR__)
+    ->ignoreVCSIgnored(true)
+    ->exclude([
+        'Resources/Public/JavaScript',
+    ])
+;

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /Tests                    export-ignore
 /.crowdin.yaml            export-ignore
 /.editorconfig            export-ignore
+/.editorconfig-lint.php   export-ignore
 /.gitattributes           export-ignore
 /.gitignore               export-ignore
 /.php-cs-fixer.php        export-ignore

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Lint composer.json
         run: composer lint:composer -- --dry-run
       - name: Lint Editorconfig
-        run: .Build/bin/ec --git-only
+        run: .Build/bin/ec --finder-config .editorconfig-lint.php
       - name: Lint PHP
         run: composer lint:php -- --dry-run
 

--- a/captainhook.json
+++ b/captainhook.json
@@ -14,7 +14,7 @@
 		"enabled": true,
 		"actions": [
 			{
-				"action": ".Build/bin/ec --git-only",
+				"action": ".Build/bin/ec --finder-config .editorconfig-lint.php",
 				"options": [],
 				"conditions": [
 					{

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
 			"@lint:php"
 		],
 		"lint:composer": "@composer normalize --no-check-lock --no-update-lock",
-		"lint:editorconfig": "ec --fix --git-only",
+		"lint:editorconfig": "ec --finder-config .editorconfig-lint.php --fix",
 		"lint:php": "php-cs-fixer fix",
 		"sca": [
 			"@sca:php"


### PR DESCRIPTION
This PR provides a Finder instance to exclude

- [x] untracked files and
- [x] generated JavaScript files

from `.editorconfig` linting.