### PR TITLE
[TASK] Drop support for `develop` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
-    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # TYPO3 extension `warming`
 
-[![Coverage](https://codecov.io/gh/eliashaeussler/typo3-warming/branch/develop/graph/badge.svg?token=7M3UXACCKA)](https://codecov.io/gh/eliashaeussler/typo3-warming)
+[![Coverage](https://codecov.io/gh/eliashaeussler/typo3-warming/branch/main/graph/badge.svg?token=7M3UXACCKA)](https://codecov.io/gh/eliashaeussler/typo3-warming)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2f55fa181559fdda4cc1/maintainability)](https://codeclimate.com/github/eliashaeussler/typo3-warming/maintainability)
 [![Tests](https://github.com/eliashaeussler/typo3-warming/actions/workflows/tests.yaml/badge.svg)](https://github.com/eliashaeussler/typo3-warming/actions/workflows/tests.yaml)
 [![CGL](https://github.com/eliashaeussler/typo3-warming/actions/workflows/cgl.yaml/badge.svg)](https://github.com/eliashaeussler/typo3-warming/actions/workflows/cgl.yaml)


### PR DESCRIPTION
With this PR, support for the `develop` branch is dropped. The `main` branch will be used as main branch later on.