### PR TITLE
[FEATURE] Add support for eliashaeussler/cache-warmup 0.7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": ">= 7.1 < 8.2",
 		"ext-json": "*",
-		"eliashaeussler/cache-warmup": ">= 0.4.0 < 0.7.0",
+		"eliashaeussler/cache-warmup": ">= 0.4.0 < 0.8.0",
 		"guzzlehttp/guzzle": ">= 6.3.0 < 8.0.0",
 		"guzzlehttp/psr7": ">= 1.4.0 < 3.0.0",
 		"psr/http-message": "^1.0",


### PR DESCRIPTION
This PR widens the possibly installable versions of `eliashaeussler/cache-warmup` to include 0.7.x versions as well.