### PR TITLE
[BUGFIX] Widen version ranges for TER library dependencies

### DIFF
--- a/Resources/Private/Libs/Build/composer.json
+++ b/Resources/Private/Libs/Build/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"eliashaeussler/cache-warmup": "^0.4.0 || ^0.5.0",
+		"eliashaeussler/cache-warmup": ">= 0.4.0 < 0.9.0",
 		"symfony/polyfill-php80": "^1.23"
 	},
 	"config": {


### PR DESCRIPTION
This PR aligns the version requirements for TER library dependencies with the version ranges declared in `composer.json`.