### PR TITLE
[BUGFIX] Build PHAR files for TER packaging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,8 +69,20 @@ jobs:
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
 
+      - name: Reset files
+        run: git reset --hard HEAD && git clean -dfx
+
+      # PHAR files
+      - name: Build PHAR file
+        run: |
+          composer global require clue/phar-composer
+          composer install -d Resources/Private/Libs/Build
+          composer global exec phar-composer build Resources/Private/Libs/Build Resources/Private/Libs/vendors.phar
+      - name: Include PHAR file
+        run: echo "\\EliasHaeussler\\Typo3Warming\\Configuration\\Extension::loadVendorLibraries();" >> ext_localconf.php
+
+      # Release
       - name: Publish to TER
         run: |
-          git reset --hard HEAD && git clean -dfx
           php ~/.composer/vendor/bin/tailor set-version "${{ steps.get-version.outputs.version }}" --no-docs
           php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ steps.get-comment.outputs.comment }}" "${{ steps.get-version.outputs.version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,11 +63,7 @@ jobs:
         with:
           php-version: 7.4
           extensions: intl, mbstring, json, zip, curl
-          tools: composer:v2
-
-      # Install tailor
-      - name: Install tailor
-        run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
+          tools: composer:v2, typo3/tailor, clue/phar-composer
 
       - name: Reset files
         run: git reset --hard HEAD && git clean -dfx
@@ -75,7 +71,6 @@ jobs:
       # PHAR files
       - name: Build PHAR file
         run: |
-          composer global require clue/phar-composer
           composer install -d Resources/Private/Libs/Build
           composer global exec phar-composer build Resources/Private/Libs/Build Resources/Private/Libs/vendors.phar
       - name: Include PHAR file


### PR DESCRIPTION
This PR re-adds the build of PHAR file used for TER packaging. It seems like this was removed by accident when switching from GitLab to GitHub.