### PR TITLE
[BUGFIX] Use `symfony/serializer` to properly denormalize query params

### DIFF
--- a/Classes/Request/WarmupRequest.php
+++ b/Classes/Request/WarmupRequest.php
@@ -26,6 +26,8 @@ namespace EliasHaeussler\Typo3Warming\Request;
 use EliasHaeussler\CacheWarmup\CrawlingState;
 use EliasHaeussler\Typo3Warming\Controller\CacheWarmupController;
 use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Utility\StringUtility;
 
 /**
  * WarmupRequest
@@ -41,7 +43,7 @@ class WarmupRequest
     protected $id;
 
     /**
-     * @var string
+     * @var CacheWarmupController::MODE_*
      */
     protected $mode;
 
@@ -49,6 +51,16 @@ class WarmupRequest
      * @var int|null
      */
     protected $languageId;
+
+    /**
+     * @var int|null
+     */
+    protected $pageId;
+
+    /**
+     * @var Site|null
+     */
+    protected $site;
 
     /**
      * @var UriInterface[]
@@ -65,11 +77,19 @@ class WarmupRequest
      */
     protected $updateCallback;
 
-    public function __construct(string $id, string $mode = CacheWarmupController::MODE_SITE, int $languageId = null)
-    {
-        $this->id = $id;
+    /**
+     * @param CacheWarmupController::MODE_* $mode
+     */
+    public function __construct(
+        string $requestId = null,
+        string $mode = CacheWarmupController::MODE_SITE,
+        int $languageId = null,
+        int $pageId = null
+    ) {
+        $this->id = $requestId ?? StringUtility::getUniqueId('_');
         $this->mode = $mode;
         $this->languageId = $languageId;
+        $this->pageId = $pageId;
     }
 
     public function getId(): string
@@ -85,6 +105,11 @@ class WarmupRequest
     public function getLanguageId(): ?int
     {
         return $this->languageId;
+    }
+
+    public function getPageId(): ?int
+    {
+        return $this->pageId;
     }
 
     public function getTotal(): int
@@ -156,6 +181,16 @@ class WarmupRequest
     public function getFailedCrawls(): \Generator
     {
         yield from $this->filterByState(CrawlingState::FAILED);
+    }
+
+    public function getSite(): ?Site
+    {
+        return $this->site;
+    }
+
+    public function setSite(?Site $site): void
+    {
+        $this->site = $site;
     }
 
     public function getUpdateCallback(): ?callable

--- a/Tests/Unit/Request/WarmupRequestTest.php
+++ b/Tests/Unit/Request/WarmupRequestTest.php
@@ -27,6 +27,7 @@ use EliasHaeussler\CacheWarmup\CrawlingState;
 use EliasHaeussler\Typo3Warming\Controller\CacheWarmupController;
 use EliasHaeussler\Typo3Warming\Request\WarmupRequest;
 use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -45,7 +46,7 @@ class WarmupRequestTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->subject = new WarmupRequest('foo', CacheWarmupController::MODE_SITE, 1);
+        $this->subject = new WarmupRequest('foo', CacheWarmupController::MODE_SITE, 1, 7);
     }
 
     /**
@@ -70,6 +71,14 @@ class WarmupRequestTest extends UnitTestCase
     public function getLanguageIdReturnsLanguageId(): void
     {
         self::assertSame(1, $this->subject->getLanguageId());
+    }
+
+    /**
+     * @test
+     */
+    public function getPageIdReturnsPageId(): void
+    {
+        self::assertSame(7, $this->subject->getPageId());
     }
 
     /**
@@ -203,6 +212,19 @@ class WarmupRequestTest extends UnitTestCase
         ];
 
         self::assertSame($expected, iterator_to_array($this->subject->getFailedCrawls()));
+    }
+
+    /**
+     * @test
+     */
+    public function getSiteReturnsSite(): void
+    {
+        self::assertNull($this->subject->getSite());
+
+        $site = new Site('foo', 7, []);
+        $this->subject->setSite($site);
+
+        self::assertSame($site, $this->subject->getSite());
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"psr/log": "^1.0",
 		"symfony/console": ">= 4.0 < 6.0",
 		"symfony/polyfill-php80": "^1.23",
+		"symfony/serializer": ">= 4.0 < 6.0",
 		"typo3/cms-backend": "~10.4.0 || ~11.5.0",
 		"typo3/cms-core": "~10.4.0 || ~11.5.0",
 		"typo3/cms-extbase": "~10.4.0 || ~11.5.0",


### PR DESCRIPTION
The `symfony/serializer` component is now used to denormalize the request's query params to a `WarmupRequest` object. For this, the appropriate class has been aligned with the structure of the expected query params, making it possible to directly normalize them to it.

In addition, this is a step forward to fully support PHP 8.x and pave the way for further support of the 1.x versions of the underlying `eliashaeussler/cache-warmup` library.

Resolves: #73