### PR TITLE
[BUGFIX] Properly handle multi-language records in AccessUtility

### DIFF
--- a/Classes/Utility/AccessUtility.php
+++ b/Classes/Utility/AccessUtility.php
@@ -68,7 +68,18 @@ class AccessUtility
             $record = BackendUtility::getRecordLocalization('pages', $pageId, $languageId, 'hidden = 0');
         }
 
-        return !empty($record) && $backendUser->doesUserHaveAccess($record, $permissions);
+        // Early return if record is inaccessible
+        if (!\is_array($record) || $record === []) {
+            return false;
+        }
+
+        // Select first record inside list of records which is potentially returned by
+        // BackendUtility::getRecordLocalization()
+        if (array_is_list($record)) {
+            $record = reset($record);
+        }
+
+        return $backendUser->doesUserHaveAccess($record, $permissions);
     }
 
     protected static function isPageAccessible(int $pageId): bool

--- a/Resources/Private/Libs/Build/composer.json
+++ b/Resources/Private/Libs/Build/composer.json
@@ -13,6 +13,7 @@
 	"require": {
 		"php": "~7.4.0",
 		"eliashaeussler/cache-warmup": ">= 0.4.0 < 0.9.0",
-		"symfony/polyfill-php80": "^1.23"
+		"symfony/polyfill-php80": "^1.23",
+		"symfony/polyfill-php81": "^1.26"
 	}
 }

--- a/Resources/Private/Libs/Build/composer.lock
+++ b/Resources/Private/Libs/Build/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3feaba62df9df03e546ecead76e5b7b",
+    "content-hash": "bf4151a66a43d72ee0717c55be128edf",
     "packages": [
         {
             "name": "eliashaeussler/cache-warmup",
@@ -1305,6 +1305,85 @@
                 }
             ],
             "time": "2022-05-10T07:21:04+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/13f6d1271c663dc5ae9fb843a8f16521db7687a1",
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 		"psr/log": "^1.0",
 		"symfony/console": ">= 4.0 < 6.0",
 		"symfony/polyfill-php80": "^1.23",
+		"symfony/polyfill-php81": "^1.26",
 		"symfony/serializer": ">= 4.0 < 6.0",
 		"typo3/cms-backend": "~10.4.0 || ~11.5.0",
 		"typo3/cms-core": "~10.4.0 || ~11.5.0",


### PR DESCRIPTION
This PR fixes a bug where multi-language records are not properly handled in `AccessUtility::checkPagePermissions()`. The bug should have only occurred within the page tree context menu when logged in as non-admin user.