### PR TITLE
[DOCS] Populate link to Slack channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,3 +76,9 @@ body:
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true
+  - type: markdown
+    attributes:
+      value: >
+        :bulb: **Tip:** Have you already looked into our
+        [Slack channel](https://typo3.slack.com/archives/C0400CSGWAY)? Maybe your problem has
+        already been discussed there.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Community support
+    url: https://typo3.slack.com/archives/C0400CSGWAY
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -39,3 +39,9 @@ body:
       options:
         - label: I agree to follow this project's Code of Conduct.
           required: true
+  - type: markdown
+    attributes:
+      value: >
+        :bulb: **Tip:** Have you already looked into our
+        [Slack channel](https://typo3.slack.com/archives/C0400CSGWAY)? Maybe your problem has
+        already been discussed there.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Downloads](https://shields.io/endpoint?url=https://typo3-badges.dev/badge/warming/downloads/shields)](https://extensions.typo3.org/extension/warming)
 [![Extension stability](https://shields.io/endpoint?url=https://typo3-badges.dev/badge/warming/stability/shields)](https://extensions.typo3.org/extension/warming)
 [![TYPO3 badge](https://shields.io/endpoint?url=https://typo3-badges.dev/badge/typo3/shields)](https://typo3.org/)
+[![Slack](https://img.shields.io/badge/slack-%23ext--warming-4a154b?logo=slack)](https://typo3.slack.com/archives/C0400CSGWAY)
 
 :package:&nbsp;[Packagist](https://packagist.org/packages/eliashaeussler/typo3-warming) |
 :hatched_chick:&nbsp;[TYPO3 extension repository](https://extensions.typo3.org/extension/warming) |


### PR DESCRIPTION
This PR links the recently created Slack channel to the `README` file and issue templates.