### PR TITLE
[!!!][FEATURE] Use sitemap providers as tagged iterator

### DIFF
--- a/Classes/Sitemap/Provider/ProviderInterface.php
+++ b/Classes/Sitemap/Provider/ProviderInterface.php
@@ -36,4 +36,6 @@ use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
 interface ProviderInterface
 {
     public function get(Site $site, SiteLanguage $siteLanguage = null): ?SiteAwareSitemap;
+
+    public static function getPriority(): int;
 }

--- a/Classes/Sitemap/Provider/RobotsTxtProvider.php
+++ b/Classes/Sitemap/Provider/RobotsTxtProvider.php
@@ -79,4 +79,12 @@ class RobotsTxtProvider extends AbstractProvider
             return null;
         }
     }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public static function getPriority(): int
+    {
+        return 100;
+    }
 }

--- a/Classes/Sitemap/Provider/SiteProvider.php
+++ b/Classes/Sitemap/Provider/SiteProvider.php
@@ -53,4 +53,12 @@ class SiteProvider extends AbstractProvider
             $siteLanguage
         );
     }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public static function getPriority(): int
+    {
+        return 200;
+    }
 }

--- a/Classes/Sitemap/SitemapLocator.php
+++ b/Classes/Sitemap/SitemapLocator.php
@@ -54,19 +54,18 @@ class SitemapLocator
     protected $cacheManager;
 
     /**
-     * @var ProviderInterface[]
+     * @var iterable<ProviderInterface>
      */
     protected $providers = [];
 
     /**
-     * @param ProviderInterface[] $providers
+     * @param iterable<ProviderInterface> $providers
      */
-    public function __construct(RequestFactory $requestFactory, CacheManager $cacheManager, array $providers)
+    public function __construct(RequestFactory $requestFactory, CacheManager $cacheManager, iterable $providers)
     {
         $this->requestFactory = $requestFactory;
         $this->cacheManager = $cacheManager;
         $this->providers = $providers;
-        ksort($this->providers);
 
         $this->validateProviders();
     }

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -21,36 +21,15 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Warming\Sitemap\Provider;
+namespace EliasHaeussler\Typo3Warming\DependencyInjection;
 
-use EliasHaeussler\Typo3Warming\Sitemap\SiteAwareSitemap;
-use TYPO3\CMS\Core\Site\Entity\Site;
-use TYPO3\CMS\Core\Site\Entity\SiteLanguage;
+use EliasHaeussler\Typo3Warming\Sitemap;
+use Symfony\Component\DependencyInjection as SymfonyDI;
 
-/**
- * DefaultProvider
- *
- * @author Elias Häußler <elias@haeussler.dev>
- * @license GPL-2.0-or-later
- */
-class DefaultProvider extends AbstractProvider
-{
-    public const DEFAULT_PATH = 'sitemap.xml';
-
-    public function get(Site $site, SiteLanguage $siteLanguage = null): ?SiteAwareSitemap
-    {
-        return new SiteAwareSitemap(
-            $this->getSiteUrlWithPath($site, self::DEFAULT_PATH, $siteLanguage),
-            $site,
-            $siteLanguage
-        );
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public static function getPriority(): int
-    {
-        return -PHP_INT_MAX;
-    }
-}
+return static function (
+    SymfonyDI\Loader\Configurator\ContainerConfigurator $containerConfigurator,
+    SymfonyDI\ContainerBuilder $container
+): void {
+    $container->registerForAutoconfiguration(Sitemap\Provider\ProviderInterface::class)
+        ->addTag('warming.sitemap_provider');
+};

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -19,10 +19,7 @@ services:
   EliasHaeussler\Typo3Warming\Sitemap\SitemapLocator:
     public: true
     arguments:
-      $providers:
-        - '@EliasHaeussler\Typo3Warming\Sitemap\Provider\SiteProvider'
-        - '@EliasHaeussler\Typo3Warming\Sitemap\Provider\RobotsTxtProvider'
-        - '@EliasHaeussler\Typo3Warming\Sitemap\Provider\DefaultProvider'
+      $providers: !tagged_iterator { tag: 'warming.sitemap_provider', default_priority_method: 'getPriority' }
 
   EliasHaeussler\Typo3Warming\Command\ShowUserAgentCommand:
     tags:

--- a/README.md
+++ b/README.md
@@ -162,33 +162,19 @@ Alternatively, the command `warming:showuseragent` can be used to read the
 ### Sitemap providers
 
 The path to XML sitemaps is located using various path providers. All providers
-implement the [`ProviderInterface`](Classes/Sitemap/Provider/ProviderInterface.php).
+implement the [`ProviderInterface`](Classes/Sitemap/Provider/ProviderInterface.php)
+and are automatically tagged as `warming.sitemap_provider`. A tagged iterator is
+passed to the [`SitemapLocator`](Classes/Sitemap/SitemapLocator.php) which
+automatically contains all available sitemap providers.
 
-The [`SitemapLocator`](Classes/Sitemap/SitemapLocator.php) is fed by a list of
-providers. That list is configured in the service container using the `Services.yaml`
-file.
+All providers must return a priority by implementing the `getPriority()` method.
+The provider with the highest priority will be processed first. If any provider
+returns a valid [`SiteAwareSitemap`](Classes/Sitemap/SiteAwareSitemap.php) object,
+the remaining providers won't be processed.
 
-All providers will be processed in natural order, meaning the provider with the
-lowest array index will be processed first. If any provider returns a valid
-[`SiteAwareSitemap`](Classes/Sitemap/SiteAwareSitemap.php) object, the remaining
-providers won't be processed.
-
-You are free to modify or extend the list of path providers. Keep in mind that the
-[`DefaultProvider`](Classes/Sitemap/Provider/DefaultProvider.php) should always
-be used as last provider since it always returns a `SiteAwareSitemap` object.
-
-```yaml
-# Configuration/Services.yaml
-
-services:
-  # ...
-  EliasHaeussler\Typo3Warming\Sitemap\SitemapLocator:
-    public: true
-    arguments:
-      $providers:
-        - '@My\Vendor\Sitemap\Provider\MyCustomProvider'
-        - '@EliasHaeussler\Typo3Warming\Sitemap\Provider\DefaultProvider'
-```
+When implementing a custom provider, keep in mind that the
+[`DefaultProvider`](Classes/Sitemap/Provider/DefaultProvider.php) is always
+executed last since it always returns a `SiteAwareSitemap` object.
 
 ## :technologist: Contributing
 


### PR DESCRIPTION
With this PR, sitemap providers are now tagged as `warming.sitemap_provider`. This allows to reference all available sitemap providers and pass them as tagged iterator to the `SitemapLocator`. This also makes it easier to provide custom sitemap implementations.