### PR TITLE
[BUGFIX] Use PAT for Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MERGE_TOKEN }}
 
       # Install dependencies
       - name: Install dependencies


### PR DESCRIPTION
The `dependabot.yaml` workflow needs special permissions in order for the `stefanzweifel/git-auto-commit-action` to allow amending and pushing a modified commit. An appropriate PAT is now used instead of the default Github token.