### PR TITLE
[BUGFIX] Fetch last two commits in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          fetch-depth: 2
           token: ${{ secrets.MERGE_TOKEN }}
 
       # Install dependencies


### PR DESCRIPTION
As written in https://github.com/stefanzweifel/git-auto-commit-action#advanced-uses, the `fetch-depth` when using the `stefanzweifel/git-auto-commit-action` in combination with `git commit --amend` should be `2`. Otherwise, the created commit is created outside of the actual commit history, which causes a lot of trouble (as can be seen in #88).