### PR TITLE
[FEATURE] Declare `CacheWarmupService` as public service

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,6 +16,8 @@ services:
     public: true
   EliasHaeussler\Typo3Warming\Controller\CacheWarmupController:
     public: true
+  EliasHaeussler\Typo3Warming\Service\CacheWarmupService:
+    public: true
   EliasHaeussler\Typo3Warming\Sitemap\SitemapLocator:
     public: true
     arguments:


### PR DESCRIPTION
The `CacheWarmupService` is considered public API. Therefore, the corresponding service in the service container is now marked as `public`.