### PR TITLE
[BUGFIX] Skip CodeClimate coverage report if secret is not available

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -105,6 +105,7 @@ jobs:
         run: sed -i 's#/home/runner/work/typo3-warming/typo3-warming#${{ github.workspace }}#g' clover.xml
       - name: CodeClimate report
         uses: paambaati/codeclimate-action@v3.0.0
+        if: env.CC_TEST_REPORTER_ID
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:


### PR DESCRIPTION
Sometimes the required `CC_TEST_REPORTER_ID` secret for CodeClimate is not available, e.g. within forks. Since codecov already handles coverage reports, we only run CodeClimate if the appropriate secret exists.