### PR TITLE
[FEATURE] Add support for configurable crawlers

### DIFF
--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -73,6 +73,11 @@ class WarmupCommand extends Command
      */
     protected $siteFinder;
 
+    /**
+     * @var SymfonyStyle
+     */
+    protected $io;
+
     public function __construct(
         CacheWarmupService $warmupService,
         Configuration $configuration,
@@ -192,86 +197,108 @@ class WarmupCommand extends Command
         );
     }
 
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $languages = iterator_to_array($this->resolveLanguages($input->getOption('languages')));
-        $urls = array_unique(iterator_to_array($this->resolveUrls($input->getOption('pages'), $languages)));
-        $sitemaps = array_unique(iterator_to_array($this->resolveSitemaps($input->getOption('sites'), $languages)), SORT_REGULAR);
-        $limit = abs((int)$input->getOption('limit'));
+        // Initialize sub-command
+        $subCommand = new CacheWarmupCommand();
+        $subCommand->setApplication($this->getApplication() ?? new Application());
+        $subCommandInput = $this->initializeSubCommandInput($subCommand, $input);
+        $subCommandInput->setInteractive(false);
 
-        // Exit if neither pages nor sites are given
-        if (\count($urls) + \count($sitemaps) === 0) {
-            $io->error('You need to define at least one page or site.');
-            return 1;
-        }
-
-        $io->writeln('Running <info>cache warmup</info> by <info>Elias Häußler</info> and contributors.');
-
-        // Initialize crawler
-        $crawler = $this->configuration->getVerboseCrawler();
-        if (empty($crawler)) {
-            $crawler = Configuration::DEFAULT_VERBOSE_CRAWLER;
-        }
-
-        // Initialize application
-        $application = $this->getApplication();
-        if ($application === null) {
-            $application = new Application();
-            $application->add($this);
-        }
+        $output->writeln('Running <info>cache warmup</info> by <info>Elias Häußler</info> and contributors.');
 
         // Run cache warmup in sub command from eliashaeussler/cache-warmup
-        $application->add($subCommand = new CacheWarmupCommand());
+        $statusCode = $subCommand->run($subCommandInput, $output);
+
+        // Fail if strict mode is enabled and at least one crawl was erroneous
+        if ($input->getOption('strict') && $statusCode > 0) {
+            return $statusCode;
+        }
+
+        return 0;
+    }
+
+    protected function initializeSubCommandInput(CacheWarmupCommand $subCommand, InputInterface $input): ArrayInput
+    {
+        // Resolve input options
+        $languages = $this->resolveLanguages($input->getOption('languages'));
+        $urls = array_unique($this->resolveUrls($input->getOption('pages'), $languages));
+        $sitemaps = array_unique($this->resolveSitemaps($input->getOption('sites'), $languages), SORT_REGULAR);
+        $limit = abs((int)$input->getOption('limit'));
+
+        // Fetch crawler and crawler options
+        $crawler = $this->configuration->getVerboseCrawler();
+        $crawlerOptions = $this->configuration->getVerboseCrawlerOptions();
+
+        // Initialize sub-command parameters
         $subCommandParameters = [
             'sitemaps' => $sitemaps,
             '--urls' => $urls,
             '--limit' => $limit,
             '--crawler' => $crawler,
         ];
-        $subCommandInput = new ArrayInput($subCommandParameters);
-        $returnCode = $subCommand->run($subCommandInput, $output);
 
-        // Fail if strict mode is enabled and at least one crawl was erroneous
-        if ($input->getOption('strict') && $returnCode > 0) {
-            return 2;
+        // Early return if no crawler options are given
+        if ($crawlerOptions === []) {
+            return new ArrayInput($subCommandParameters, $subCommand->getDefinition());
         }
 
-        return 0;
+        // Add crawler options to sub-command parameters
+        if ($subCommand->getDefinition()->hasOption('crawler-options')) {
+            $subCommandParameters['--crawler-options'] = json_encode($crawlerOptions);
+        } else {
+            $this->io->writeln([
+                '<comment>This version of eliashaeussler/cache-warmup does not yet support crawler options.</comment>',
+                '<comment>Please upgrade to version 0.7.13 or any later version.</comment>',
+            ]);
+        }
+
+        return new ArrayInput($subCommandParameters, $subCommand->getDefinition());
     }
 
     /**
-     * @param string[]|int[] $pages
-     * @param int[] $languages
-     * @return \Generator<UriInterface>
+     * @param list<string|int> $pages
+     * @param list<int> $languages
+     * @return list<UriInterface>
      * @throws SiteNotFoundException
      */
-    protected function resolveUrls(array $pages, array $languages): \Generator
+    protected function resolveUrls(array $pages, array $languages): array
     {
+        $resolvedUrls = [];
+
         foreach ($pages as $pageList) {
             foreach (GeneralUtility::intExplode(',', (string)$pageList, true) as $page) {
                 $languageIds = $languages;
-                if ([self::ALL_LANGUAGES] === $languageIds) {
+                if ($languageIds === [self::ALL_LANGUAGES]) {
                     $site = $this->siteFinder->getSiteByPageId($page);
                     $languageIds = array_keys($site->getLanguages());
                 }
                 foreach ($languageIds as $languageId) {
-                    yield $this->warmupService->generateUri($page, $languageId);
+                    $resolvedUrls[] = $this->warmupService->generateUri($page, $languageId);
                 }
             }
         }
+
+        return $resolvedUrls;
     }
 
     /**
-     * @param string[]|int[] $sites
-     * @param int[] $languages
-     * @return \Generator<SiteAwareSitemap>
+     * @param list<string|int> $sites
+     * @param list<int> $languages
+     * @return list<SiteAwareSitemap>
      * @throws SiteNotFoundException
      * @throws UnsupportedConfigurationException
      * @throws UnsupportedSiteException
      */
-    protected function resolveSitemaps(array $sites, array $languages): \Generator
+    protected function resolveSitemaps(array $sites, array $languages): array
     {
+        $resolvedSitemaps = [];
+
         foreach ($sites as $siteList) {
             foreach (GeneralUtility::trimExplode(',', (string)$siteList, true) as $site) {
                 if (MathUtility::canBeInterpretedAsInteger($site)) {
@@ -284,28 +311,33 @@ class WarmupCommand extends Command
                     $languageIds = array_keys($site->getLanguages());
                 }
                 foreach ($languageIds as $languageId) {
-                    yield $this->sitemapLocator->locateBySite($site, $site->getLanguageById($languageId));
+                    $resolvedSitemaps[] = $this->sitemapLocator->locateBySite($site, $site->getLanguageById($languageId));
                 }
             }
         }
+
+        return $resolvedSitemaps;
     }
 
     /**
-     * @param string[]|int[] $languages
-     * @return \Generator<int>
+     * @param list<string|int> $languages
+     * @return list<int>
      */
-    protected function resolveLanguages(array $languages): \Generator
+    protected function resolveLanguages(array $languages): array
     {
+        $resolvedLanguages = [];
+
         if ($languages === []) {
             // Run cache warmup for all languages by default
-            yield self::ALL_LANGUAGES;
-            return;
+            return [self::ALL_LANGUAGES];
         }
 
         foreach ($languages as $languageList) {
             foreach (GeneralUtility::intExplode(',', (string)$languageList, true) as $languageId) {
-                yield $languageId;
+                $resolvedLanguages[] = $languageId;
             }
         }
+
+        return $resolvedLanguages;
     }
 }

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -99,6 +99,20 @@ final class Configuration
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    public function getCrawlerOptions(): array
+    {
+        try {
+            $json = $this->configuration->get(Extension::KEY, 'crawlerOptions');
+
+            return $this->parseCrawlerOptions($json);
+        } catch (Exception $e) {
+            return [];
+        }
+    }
+
+    /**
      * @return class-string<CrawlerInterface>
      */
     public function getVerboseCrawler(): string
@@ -109,6 +123,20 @@ final class Configuration
             return !empty($crawler) ? (string)$crawler : self::DEFAULT_VERBOSE_CRAWLER;
         } catch (Exception $e) {
             return self::DEFAULT_VERBOSE_CRAWLER;
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getVerboseCrawlerOptions(): array
+    {
+        try {
+            $json = $this->configuration->get(Extension::KEY, 'verboseCrawlerOptions');
+
+            return $this->parseCrawlerOptions($json);
+        } catch (Exception $e) {
+            return [];
         }
     }
 
@@ -130,6 +158,25 @@ final class Configuration
         } catch (Exception $e) {
             return [];
         }
+    }
+
+    /**
+     * @param mixed $json
+     * @return array<string, mixed>
+     */
+    private function parseCrawlerOptions($json): array
+    {
+        if (!\is_string($json)) {
+            return [];
+        }
+
+        $crawlerOptions = json_decode($json, true);
+
+        if (!\is_array($crawlerOptions)) {
+            return [];
+        }
+
+        return $crawlerOptions;
     }
 
     private function generateUserAgent(): string

--- a/Classes/Service/CacheWarmupService.php
+++ b/Classes/Service/CacheWarmupService.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Warming\Service;
 
 use EliasHaeussler\CacheWarmup\CacheWarmer;
+use EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface;
 use EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface;
 use EliasHaeussler\Typo3Warming\Configuration\Configuration;
 use EliasHaeussler\Typo3Warming\Crawler\RequestAwareInterface;
@@ -80,7 +81,10 @@ class CacheWarmupService implements LoggerAwareInterface
         $this->siteFinder = $siteFinder;
         $this->sitemapLocator = $sitemapLocator;
         $this->limit = $configuration->getLimit();
-        $this->crawler = $this->initializeCrawler($configuration->getCrawler());
+        $this->crawler = $this->initializeCrawler(
+            $configuration->getCrawler(),
+            $configuration->getCrawlerOptions()
+        );
     }
 
     /**
@@ -149,22 +153,24 @@ class CacheWarmupService implements LoggerAwareInterface
 
     /**
      * @param class-string<CrawlerInterface>|CrawlerInterface $crawler
+     * @param array<string, mixed> $options
      * @throws UnsupportedConfigurationException
      */
-    public function setCrawler($crawler): self
+    public function setCrawler($crawler, array $options = []): self
     {
-        $this->crawler = $this->initializeCrawler($crawler);
+        $this->crawler = $this->initializeCrawler($crawler, $options);
         return $this;
     }
 
     /**
      * @param class-string<CrawlerInterface>|CrawlerInterface $crawler
+     * @param array<string, mixed> $options
      * @throws UnsupportedConfigurationException
      */
-    protected function initializeCrawler($crawler): CrawlerInterface
+    protected function initializeCrawler($crawler, array $options = []): CrawlerInterface
     {
         if ($crawler instanceof CrawlerInterface) {
-            return $crawler;
+            goto configurableCrawler;
         }
 
         // Use default crawler if no custom crawler is given
@@ -187,6 +193,15 @@ class CacheWarmupService implements LoggerAwareInterface
             throw UnsupportedConfigurationException::forMissingImplementation($crawler, CrawlerInterface::class);
         }
 
-        return GeneralUtility::makeInstance($crawler);
+        // Instantiate crawler
+        $crawler = GeneralUtility::makeInstance($crawler);
+
+        // Apply crawler options to configurable crawler
+        configurableCrawler:
+        if ($crawler instanceof ConfigurableCrawlerInterface) {
+            $crawler->setOptions($options);
+        }
+
+        return $crawler;
     }
 }

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -36,6 +36,17 @@ The extension currently provides the following configuration options:
         Custom crawlers must implement
         :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\CrawlerInterface`.
 
+.. _extconf-crawlerOptions:
+
+.. confval:: crawlerOptions
+
+    :type: string (JSON)
+
+    JSON-encoded string of custom crawler options for the default
+    :ref:`crawler <extconf-crawler>`. Applies only to crawlers implementing the
+    :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`.
+    For more information read :ref:`configurable-crawlers`.
+
 .. _extconf-verboseCrawler:
 
 .. confval:: verboseCrawler
@@ -49,3 +60,14 @@ The extension currently provides the following configuration options:
 
         Custom verbose crawlers must implement
         :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\VerboseCrawlerInterface`.
+
+.. _extconf-verboseCrawlerOptions:
+
+.. confval:: verboseCrawlerOptions
+
+    :type: string (JSON)
+
+    JSON-encoded string of custom crawler options for the verbose
+    :ref:`crawler <extconf-verboseCrawler>`. Applies only to crawlers implementing the
+    :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`.
+    For more information read :ref:`configurable-crawlers`.

--- a/Documentation/DeveloperCorner/Crawlers.rst
+++ b/Documentation/DeveloperCorner/Crawlers.rst
@@ -78,7 +78,7 @@ also a
 that redirects user-oriented output to an instance of
 :php:interface:`Symfony\\Component\\Console\\Output\\OutputInterface`.
 
-.. _configuratble-crawlers:
+.. _configurable-crawlers:
 
 Configurable crawlers
 ---------------------

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -4,5 +4,11 @@ limit = 250
 # cat=basic/20; type=string; label=Default crawler:Provide the FQCN of the crawler to be used for standard warmup requests. A crawler must implement the interface "EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface".
 crawler = EliasHaeussler\Typo3Warming\Crawler\ConcurrentUserAgentCrawler
 
+# cat=basic/25; type=string; label=Default crawler options (JSON-encoded string):Provide crawler options for the default crawler. Applies only if the default crawler implements the interface "EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface".
+crawlerOptions =
+
 # cat=basic/30; type=string; label=Verbose crawler:Provide the FQCN of the crawler to be used for verbose warmup requests. A crawler must implement the interface "EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface".
 verboseCrawler = EliasHaeussler\Typo3Warming\Crawler\OutputtingUserAgentCrawler
+
+# cat=basic/35; type=string; label=Verbose crawler options (JSON-encoded string):Provide crawler options for the verbose crawler. Applies only if the verbose crawler implements the interface "EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface".
+verboseCrawlerOptions =


### PR DESCRIPTION
This commit adds support for configurable crawlers that were introduced with eliashaeussler/cache-warmup#59 and is available since `0.7.13` of [eliashaeussler/cache-warmup](https://github.com/eliashaeussler/cache-warmup). For this, two new extension configuration options have been added:

- `crawlerOptions` (for default crawlers)
- `verboseCrawlerOption` (for verbose crawlers)