### PR TITLE
[BUGFIX] Harden Configuration API against invalid crawler class names

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Warming\Configuration;
 
 use EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface;
+use EliasHaeussler\CacheWarmup\Crawler\VerboseCrawlerInterface;
 use EliasHaeussler\Typo3Warming\Crawler\ConcurrentUserAgentCrawler;
 use EliasHaeussler\Typo3Warming\Crawler\OutputtingUserAgentCrawler;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
@@ -92,7 +93,11 @@ final class Configuration
                 return self::DEFAULT_CRAWLER;
             }
 
-            return $crawler ?: self::DEFAULT_CRAWLER;
+            if (!\in_array(CrawlerInterface::class, class_implements($crawler) ?: [])) {
+                return self::DEFAULT_CRAWLER;
+            }
+
+            return $crawler;
         } catch (Exception $e) {
             return self::DEFAULT_CRAWLER;
         }
@@ -113,14 +118,23 @@ final class Configuration
     }
 
     /**
-     * @return class-string<CrawlerInterface>
+     * @return class-string<VerboseCrawlerInterface>
      */
     public function getVerboseCrawler(): string
     {
         try {
-            /** @var class-string<CrawlerInterface>|null $crawler */
+            /** @var class-string<VerboseCrawlerInterface>|null $crawler */
             $crawler = $this->configuration->get(Extension::KEY, 'verboseCrawler');
-            return !empty($crawler) ? (string)$crawler : self::DEFAULT_VERBOSE_CRAWLER;
+
+            if (!\is_string($crawler)) {
+                return self::DEFAULT_VERBOSE_CRAWLER;
+            }
+
+            if (!\in_array(VerboseCrawlerInterface::class, class_implements($crawler) ?: [])) {
+                return self::DEFAULT_VERBOSE_CRAWLER;
+            }
+
+            return $crawler;
         } catch (Exception $e) {
             return self::DEFAULT_VERBOSE_CRAWLER;
         }

--- a/Documentation/DeveloperCorner/ConfigurationAPI.rst
+++ b/Documentation/DeveloperCorner/ConfigurationAPI.rst
@@ -32,7 +32,7 @@ an appropriate class method.
 
         Get the configured :ref:`verbose crawler class <extconf-verboseCrawler>`.
 
-        :returntype: class-string<EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface>
+        :returntype: class-string<EliasHaeussler\CacheWarmup\Crawler\VerboseCrawlerInterface>
 
     ..  php:method:: getUserAgent()
 


### PR DESCRIPTION
Both `Configuration::getCrawler()` and `Configuration::getVerboseCrawler()` now fall back to the default crawler implementations in case an invalid class name is configured.