### PR TITLE
[!!!][TASK] Drop support for eliashaeussler/cache-warmup 0.4.x

### DIFF
--- a/Resources/Private/Libs/Build/composer.json
+++ b/Resources/Private/Libs/Build/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": "~7.4.0",
-		"eliashaeussler/cache-warmup": "~0.4",
+		"eliashaeussler/cache-warmup": "~0.5",
 		"symfony/polyfill-php80": "^1.23",
 		"symfony/polyfill-php81": "^1.26",
 		"symfony/serializer": "^4.4 || ^5.4 || ^6.0"

--- a/Resources/Private/Libs/Build/composer.lock
+++ b/Resources/Private/Libs/Build/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "088ed5d6a43583c29e91d80960b99b5f",
+    "content-hash": "2410044cc5b9a7878b8196e1705ac7a9",
     "packages": [
         {
             "name": "eliashaeussler/cache-warmup",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require": {
 		"php": "~7.4.0 || ~8.0.0 || ~8.1.0",
 		"ext-json": "*",
-		"eliashaeussler/cache-warmup": "~0.4",
+		"eliashaeussler/cache-warmup": "~0.5",
 		"guzzlehttp/guzzle": "^6.3 || ^7.0",
 		"guzzlehttp/psr7": "^1.4 || ^2.0",
 		"psr/http-message": "^1.0",


### PR DESCRIPTION
This PR drops support for `eliashaeussler/cache-warmup` 0.4.x since this version is pretty outdated and makes it hard to test the crawling behavior.