### PR TITLE
[BUGFIX] Assure permitted cache warmup options are shown in context menu

### DIFF
--- a/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
+++ b/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
@@ -103,6 +103,11 @@ class CacheWarmupProvider extends PageProvider
             return true;
         }
 
+        // Language items in sub-menus are already filtered
+        if (str_starts_with($itemName, 'lang_')) {
+            return true;
+        }
+
         if (\in_array($itemName, $this->disabledItems, true)) {
             return false;
         }


### PR DESCRIPTION
With this PR, a bug within context menu items has been fixed. Language sub-menus are not validated twice to avoid hiding possible cache warmup options for permitted users.