### PR TITLE
[BUGFIX] Handle missing access to default language in backend toolbar

### DIFF
--- a/Classes/Controller/CacheWarmupController.php
+++ b/Classes/Controller/CacheWarmupController.php
@@ -287,9 +287,9 @@ class CacheWarmupController
                 $siteLanguage = $sitemap->getSiteLanguage();
                 \assert($siteLanguage instanceof SiteLanguage);
 
-                $languageIdentifier = $siteLanguage === $site->getDefaultLanguage() ? 'default' : $siteLanguage->getLanguageId();
                 $sitemapConfiguration = [
                     'language' => $siteLanguage,
+                    'isDefaultLanguage' => $siteLanguage === $site->getDefaultLanguage(),
                 ];
 
                 if ($this->sitemapLocator->siteContainsSitemap($site, $siteLanguage)) {
@@ -299,7 +299,7 @@ class CacheWarmupController
                     $sitemapConfiguration['missing'] = true;
                 }
 
-                $action['sitemaps'][$languageIdentifier] = $sitemapConfiguration;
+                $action['sitemaps'][] = $sitemapConfiguration;
             }
 
             // Add flag if no site language has a sitemap

--- a/Resources/Private/Partials/ToolbarItemAction.html
+++ b/Resources/Private/Partials/ToolbarItemAction.html
@@ -3,13 +3,13 @@
       data-namespace-typo3-fluid="true">
 
 <div class="dropdown-table-row">
-    <f:if condition="{action.sitemaps -> f:count()} <= 1 || {action.missing}">
+    <f:if condition="({action.sitemaps -> f:count()} == 1 && {action.sitemaps.0.isDefaultLanguage}) || {action.missing}">
         <f:then>
             <f:render section="action-single-language" arguments="{
                 title: action.title,
                 pageId: action.pageId,
                 iconIdentifier: action.iconIdentifier,
-                sitemap: action.sitemaps.default
+                sitemap: action.sitemaps.0
             }" />
         </f:then>
         <f:else>

--- a/Resources/Private/Templates/CacheWarmupToolbarItemActions.html
+++ b/Resources/Private/Templates/CacheWarmupToolbarItemActions.html
@@ -4,7 +4,9 @@
 >
 
 <f:for each="{actions}" as="action">
-    <f:render partial="ToolbarItemAction" arguments="{action: action}" />
+    <f:if condition="{action.sitemaps}">
+        <f:render partial="ToolbarItemAction" arguments="{action: action}" />
+    </f:if>
 </f:for>
 
 </html>


### PR DESCRIPTION
This PR fixes an edge-case when non-backend users do not have access to the default language of a site. In this case, the sitemap selection in the backend toolbar was invalid. It will now show a language menu instead.