### PR TITLE
[FEATURE] Implement crawler option "client_config"

### DIFF
--- a/Classes/Crawler/ConcurrentUserAgentCrawler.php
+++ b/Classes/Crawler/ConcurrentUserAgentCrawler.php
@@ -25,10 +25,8 @@ namespace EliasHaeussler\Typo3Warming\Crawler;
 
 use EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler;
 use EliasHaeussler\CacheWarmup\CrawlingState;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
 
 /**
  * ConcurrentAgentCrawler
@@ -38,6 +36,7 @@ use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
  */
 class ConcurrentUserAgentCrawler extends ConcurrentCrawler implements RequestAwareInterface
 {
+    use ConfigurableClientTrait;
     use RequestAwareTrait;
     use UserAgentTrait;
 
@@ -47,11 +46,6 @@ class ConcurrentUserAgentCrawler extends ConcurrentCrawler implements RequestAwa
         foreach (parent::getRequests() as $request) {
             yield $this->applyUserAgentHeader($request->withMethod('GET'));
         }
-    }
-
-    protected function initializeClient(): ClientInterface
-    {
-        return GuzzleClientFactory::getClient();
     }
 
     public function onSuccess(ResponseInterface $response, int $index): void

--- a/Classes/Crawler/ConfigurableClientTrait.php
+++ b/Classes/Crawler/ConfigurableClientTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\Crawler;
+
+use EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface;
+use GuzzleHttp\ClientInterface;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
+/**
+ * ConfigurableClientTrait
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+trait ConfigurableClientTrait
+{
+    protected function initializeClient(): ClientInterface
+    {
+        $clientConfig = $this->getClientConfig();
+
+        // Early return if no client config is set
+        if ($clientConfig === []) {
+            return GuzzleClientFactory::getClient();
+        }
+
+        // Merge initial TYPO3 config with actual client config
+        $initialConfig = $GLOBALS['TYPO3_CONF_VARS']['HTTP'];
+        ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TYPO3_CONF_VARS']['HTTP'], $clientConfig);
+
+        // Initialize client and restore initial config
+        try {
+            $client = GuzzleClientFactory::getClient();
+        } finally {
+            $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = $initialConfig;
+        }
+
+        return $client;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getClientConfig(): array
+    {
+        if (!($this instanceof ConfigurableCrawlerInterface)) {
+            return [];
+        }
+
+        /* @phpstan-ignore-next-line */
+        return $this->options['client_config'] ?? [];
+    }
+
+    public function setOptions(array $options): void
+    {
+        parent::setOptions($options);
+
+        // Re-initialize client with updated client config
+        $this->client = $this->initializeClient();
+    }
+}

--- a/Classes/Crawler/OutputtingUserAgentCrawler.php
+++ b/Classes/Crawler/OutputtingUserAgentCrawler.php
@@ -24,9 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Warming\Crawler;
 
 use EliasHaeussler\CacheWarmup\Crawler\OutputtingCrawler;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Request;
-use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
 
 /**
  * OutputtingUserAgentCrawler
@@ -36,6 +34,7 @@ use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
  */
 class OutputtingUserAgentCrawler extends OutputtingCrawler
 {
+    use ConfigurableClientTrait;
     use UserAgentTrait;
 
     protected function getRequests(): \Iterator
@@ -44,10 +43,5 @@ class OutputtingUserAgentCrawler extends OutputtingCrawler
         foreach (parent::getRequests() as $request) {
             yield $this->applyUserAgentHeader($request->withMethod('GET'));
         }
-    }
-
-    protected function initializeClient(): ClientInterface
-    {
-        return GuzzleClientFactory::getClient();
     }
 }


### PR DESCRIPTION
This commit adds native support for the recently introduced crawler option `client_config`.

Support for this crawler was added in the upstream package `eliashaeussler/cache-warmup` with version `0.8.2` (see eliashaeussler/cache-warmup#95). Users in need for this crawler option must assure that the latest version of said upstream package is installed.

The new crawler option is only available to the default crawlers, `ConcurrentUserAgentCrawler` and `OutputtingUserAgentCrawler`. Configuration must be provided as JSON-encoded string in the appropriate extension configurations `crawlerOptions` and `verboseCrawlerOptions`.

Resolves: #85 