### PR TITLE
[BUGFIX] Fix undefined array key error in fetchSitesAction

### DIFF
--- a/Classes/Controller/CacheWarmupController.php
+++ b/Classes/Controller/CacheWarmupController.php
@@ -276,7 +276,7 @@ class CacheWarmupController
 
             $sitemapsFound = false;
             $action = [
-                'title' => $site->getConfiguration()['websiteTitle'] ?: BackendUtility::getRecordTitle('pages', $row),
+                'title' => $site->getConfiguration()['websiteTitle'] ?? BackendUtility::getRecordTitle('pages', $row),
                 'pageId' => $site->getRootPageId(),
                 'iconIdentifier' => $this->iconFactory->getIconForRecord('pages', $row)->getIdentifier(),
                 'sitemaps' => [],

--- a/Classes/Controller/CacheWarmupController.php
+++ b/Classes/Controller/CacheWarmupController.php
@@ -276,7 +276,7 @@ class CacheWarmupController
 
             $sitemapsFound = false;
             $action = [
-                'title' => $site->getConfiguration()['websiteTitle'] ?? BackendUtility::getRecordTitle('pages', $row),
+                'title' => ($site->getConfiguration()['websiteTitle'] ?? null) ?: BackendUtility::getRecordTitle('pages', $row),
                 'pageId' => $site->getRootPageId(),
                 'iconIdentifier' => $this->iconFactory->getIconForRecord('pages', $row)->getIdentifier(),
                 'sitemaps' => [],


### PR DESCRIPTION
This patch fix a PHP warning if `websiteTitle` is not set in the site configuration and needs to be fetched from the pages table

Fixes: #125