### PR TITLE
[BUGFIX] Replace deprecated job outputs in GitHub workflows

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -30,8 +30,7 @@ jobs:
       # Update PR
       - name: Get last commit message
         id: last-commit-message
-        run: |
-          echo "::set-output name=msg::$(git log -1 --pretty=%s)"
+        run: echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: ${{ steps.last-commit-message.outputs.msg }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,9 +53,9 @@ jobs:
 
       # Prepare version
       - id: get-version
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+        run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - id: get-comment
-        run: echo ::set-output name=comment::See release notes at ${{ needs.release.outputs.release-notes-url }}
+        run: echo "comment=See release notes at ${{ needs.release.outputs.release-notes-url }}" >> $GITHUB_OUTPUT
 
       # Prepare environment
       - name: Setup PHP


### PR DESCRIPTION
With GitHub [deprecating the `set-output` commands in GitHub workflows](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), the new `$GITHUB_OUTPUT` variable needs to be used instead.