### PR TITLE
[BUGFIX] Double-check record when checking permissions

### DIFF
--- a/Classes/Utility/AccessUtility.php
+++ b/Classes/Utility/AccessUtility.php
@@ -79,6 +79,12 @@ class AccessUtility
             $record = reset($record);
         }
 
+        // Early return if localized record is inaccessible
+        // (this should never happen, but makes PHPStan happy)
+        if (!\is_array($record) || $record === []) {
+            return false;
+        }
+
         return $backendUser->doesUserHaveAccess($record, $permissions);
     }
 


### PR DESCRIPTION
PHPStan 1.9 adds support for lists, therefore we must perform a type-safe check on lists. There's currently only one candidate, `AccessUtility::checkPagePermissions()`, which is now hardened.