### PR TITLE
[BUGFIX] Use codecov token in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -87,6 +87,7 @@ jobs:
       - name: codecov report
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: .Build/log/coverage
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
As codecov keeps failing and failing, we now avoid using token-less upload and instead explicitly define the token. See codecov/codecov-action#557 for reference.