### PR TITLE
[BUGFIX] Limit doktype support in page tree context menu

### DIFF
--- a/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
+++ b/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3Warming\Backend\ContextMenu\ItemProviders;
 
+use EliasHaeussler\Typo3Warming\Configuration\Configuration;
 use EliasHaeussler\Typo3Warming\Sitemap\SitemapLocator;
 use EliasHaeussler\Typo3Warming\Traits\BackendUserAuthenticationTrait;
 use EliasHaeussler\Typo3Warming\Utility\AccessUtility;
@@ -89,11 +90,17 @@ class CacheWarmupProvider extends PageProvider
      */
     protected $siteFinder;
 
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
     public function __construct(string $table, string $identifier, string $context = '')
     {
         parent::__construct($table, $identifier, $context);
         $this->sitemapLocator = GeneralUtility::makeInstance(SitemapLocator::class);
         $this->siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        $this->configuration = GeneralUtility::makeInstance(Configuration::class);
     }
 
     protected function canRender(string $itemName, string $type): bool
@@ -101,6 +108,12 @@ class CacheWarmupProvider extends PageProvider
         // Pseudo items (such as dividers) are always renderable
         if ($type !== 'item') {
             return true;
+        }
+
+        // Non-supported doktypes are never renderable
+        $doktype = (int)($this->record['doktype'] ?? null);
+        if ($doktype <= 0 || !\in_array($doktype, $this->configuration->getSupportedDoktypes(), true)) {
+            return false;
         }
 
         // Language items in sub-menus are already filtered
@@ -131,12 +144,18 @@ class CacheWarmupProvider extends PageProvider
      */
     public function addItems(array $items): array
     {
-        $this->initDisabledItems();
-        $this->initSubMenus();
+        $this->initialize();
+
         $localItems = $this->prepareItems($this->itemsConfiguration);
         $items += $localItems;
 
         return $items;
+    }
+
+    protected function initialize(): void
+    {
+        parent::initialize();
+        $this->initSubMenus();
     }
 
     public function getPriority(): int

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -28,7 +28,9 @@ use EliasHaeussler\CacheWarmup\Crawler\VerboseCrawlerInterface;
 use EliasHaeussler\Typo3Warming\Crawler\ConcurrentUserAgentCrawler;
 use EliasHaeussler\Typo3Warming\Crawler\OutputtingUserAgentCrawler;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Exception;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 
 /**
@@ -42,6 +44,9 @@ final class Configuration
     public const DEFAULT_LIMIT = 250;
     public const DEFAULT_CRAWLER = ConcurrentUserAgentCrawler::class;
     public const DEFAULT_VERBOSE_CRAWLER = OutputtingUserAgentCrawler::class;
+    public const DEFAULT_SUPPORTED_DOKTYPES = [
+        PageRepository::DOKTYPE_DEFAULT,
+    ];
 
     /**
      * @var ExtensionConfiguration
@@ -151,6 +156,24 @@ final class Configuration
             return $this->parseCrawlerOptions($json);
         } catch (Exception $e) {
             return [];
+        }
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getSupportedDoktypes(): array
+    {
+        try {
+            $doktypes = $this->configuration->get(Extension::KEY, 'supportedDoktypes');
+
+            if (!\is_string($doktypes)) {
+                return self::DEFAULT_SUPPORTED_DOKTYPES;
+            }
+
+            return GeneralUtility::intExplode(',', $doktypes, true);
+        } catch (Exception $e) {
+            return self::DEFAULT_SUPPORTED_DOKTYPES;
         }
     }
 

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -71,3 +71,15 @@ The extension currently provides the following configuration options:
     :ref:`crawler <extconf-verboseCrawler>`. Applies only to crawlers implementing the
     :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`.
     For more information read :ref:`configurable-crawlers`.
+
+.. _extconf-supportedDoktypes:
+
+.. confval:: supportedDoktypes
+
+    :type: string (comma-separated list)
+    :Default: 1
+
+    Comma-separated list of doktypes to be supported for cache warmup in the
+    :ref:`page tree <page-tree>` context menu. Defaults to default pages with doktype
+    :php:`1` only. If your project implements custom doktypes, you can add them here to
+    support cache warmup from the context menu.

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -12,3 +12,6 @@ verboseCrawler = EliasHaeussler\Typo3Warming\Crawler\OutputtingUserAgentCrawler
 
 # cat=basic/35; type=string; label=Verbose crawler options (JSON-encoded string):Provide crawler options for the verbose crawler. Applies only if the verbose crawler implements the interface "EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface".
 verboseCrawlerOptions =
+
+# cat=pageTree/10; type=string; label=Supported doktypes in page tree:Provide a comma-separated list of doktypes for which cache warmup should be available in the page tree context menu.
+supportedDoktypes = 1


### PR DESCRIPTION
Only a limited set of doktypes should be available for cache warmup in page tree context menu. This PR adds a new extension configuration to limit this set, defaulting to default pages (`1`) only.

Resolves: #161