### PR TITLE
[BUGFIX] Use non-conflicting priority for context menu item provider

### DIFF
--- a/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
+++ b/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
@@ -160,7 +160,7 @@ class CacheWarmupProvider extends PageProvider
 
     public function getPriority(): int
     {
-        return 50;
+        return 45;
     }
 
     protected function initSubMenus(): void


### PR DESCRIPTION
The context menu item provider distributed by EXT:impexp already uses priority 50. In order to avoid conflicts with said provider, we now use another priority for our provider.