### PR TITLE
[DOCS] Streamline indentation to 4 spaces

### DIFF
--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _extension-configuration:
+..  _extension-configuration:
 
 =======================
 Extension configuration
@@ -8,37 +8,37 @@ Extension configuration
 
 The extension currently provides the following configuration options:
 
-.. _extconf-limit:
+..  _extconf-limit:
 
-.. confval:: limit
+..  confval:: limit
 
     :type: integer
     :Default: 250
 
     Allows to limit the amount of crawled pages in one iteration.
 
-    .. tip::
+    ..  tip::
 
         Can be set to :typoscript:`0` to crawl all available pages in
         XML sitemaps.
 
-.. _extconf-crawler:
+..  _extconf-crawler:
 
-.. confval:: crawler
+..  confval:: crawler
 
     :type: string (FQCN)
     :Default: :php:class:`EliasHaeussler\\Typo3Warming\\Crawler\\ConcurrentUserAgentCrawler`
 
     Default crawler to be used for crawling the requested pages.
 
-    .. note::
+    ..  note::
 
         Custom crawlers must implement
         :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\CrawlerInterface`.
 
-.. _extconf-crawlerOptions:
+..  _extconf-crawlerOptions:
 
-.. confval:: crawlerOptions
+..  confval:: crawlerOptions
 
     :type: string (JSON)
 
@@ -47,23 +47,23 @@ The extension currently provides the following configuration options:
     :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`.
     For more information read :ref:`configurable-crawlers`.
 
-.. _extconf-verboseCrawler:
+..  _extconf-verboseCrawler:
 
-.. confval:: verboseCrawler
+..  confval:: verboseCrawler
 
     :type: string (FQCN)
     :Default: :php:class:`EliasHaeussler\\Typo3Warming\\Crawler\\OutputtingUserAgentCrawler`
 
     Verbose crawler to be used for cache warmup from the command-line.
 
-    .. note::
+    ..  note::
 
         Custom verbose crawlers must implement
         :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\VerboseCrawlerInterface`.
 
-.. _extconf-verboseCrawlerOptions:
+..  _extconf-verboseCrawlerOptions:
 
-.. confval:: verboseCrawlerOptions
+..  confval:: verboseCrawlerOptions
 
     :type: string (JSON)
 
@@ -72,9 +72,9 @@ The extension currently provides the following configuration options:
     :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`.
     For more information read :ref:`configurable-crawlers`.
 
-.. _extconf-supportedDoktypes:
+..  _extconf-supportedDoktypes:
 
-.. confval:: supportedDoktypes
+..  confval:: supportedDoktypes
 
     :type: string (comma-separated list)
     :Default: 1

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _configuration:
+..  _configuration:
 
 =============
 Configuration
@@ -13,7 +13,7 @@ your own crawler implementations.
 
 Learn what configuration options are available on the following pages:
 
-.. toctree::
+..  toctree::
     :maxdepth: 3
 
     ExtensionConfiguration

--- a/Documentation/Configuration/Permissions.rst
+++ b/Documentation/Configuration/Permissions.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _permissions:
+..  _permissions:
 
 ===========
 Permissions
@@ -15,7 +15,7 @@ However, you can use User TSconfig to allow cache warmup for
 specific users/usergroups and sites/pages. Add the following
 configuration to the :typoscript:`options.cacheWarmup` User TSconfig:
 
-.. confval:: allowedSites
+..  confval:: allowedSites
 
     :Path: :typoscript:`options.cacheWarmup.allowedSites`
     :type: string (comma-separated list)
@@ -25,11 +25,11 @@ configuration to the :typoscript:`options.cacheWarmup` User TSconfig:
 
     Example:
 
-    .. code-block:: typoscript
+    ..  code-block:: typoscript
 
         options.cacheWarmup.allowedSites = my-dummy-site,another-dummy-site
 
-.. confval:: allowedPages
+..  confval:: allowedPages
 
     :Path: :typoscript:`options.cacheWarmup.allowedPages`
     :type: string (comma-separated list)
@@ -39,11 +39,11 @@ configuration to the :typoscript:`options.cacheWarmup` User TSconfig:
 
     Example:
 
-    .. code-block:: typoscript
+    ..  code-block:: typoscript
 
         options.cacheWarmup.allowedPages = 1,2,3
 
-.. seealso::
+..  seealso::
 
     You might also want to check out :ref:`access-utility` for the
     actual implementation of the permission check.

--- a/Documentation/Configuration/SiteConfiguration.rst
+++ b/Documentation/Configuration/SiteConfiguration.rst
@@ -1,12 +1,12 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _site-configuration:
+..  _site-configuration:
 
 ==================
 Site configuration
 ==================
 
-.. important::
+..  important::
 
     Caches can be warmed up only if the entry point of the site
     contains the full domain name.
@@ -15,7 +15,7 @@ The cache warmup is based of the configured sites in the TYPO3 installation.
 Therefore, in order to control the cache warmup behavior, the site configuration can
 be used. The following configuration options are available for this purpose:
 
-.. confval:: xml_sitemap_path (site)
+..  confval:: xml_sitemap_path (site)
 
     :Path: xml_sitemap_path
     :type: string
@@ -23,10 +23,10 @@ be used. The following configuration options are available for this purpose:
     Path to the XML sitemap of the configured site's base language. It
     must be relative to the entry point of the site.
 
-    .. image:: ../Images/site-configuration.png
+    ..  image:: ../Images/site-configuration.png
         :alt: Configuration of XML sitemap path within the Sites module
 
-.. confval:: xml_sitemap_path (site_language)
+..  confval:: xml_sitemap_path (site_language)
 
     :Path: languages > (site language) > xml_sitemap_path
     :type: string
@@ -34,7 +34,7 @@ be used. The following configuration options are available for this purpose:
     Path to the XML sitemap of an additional site language. It must be
     relative to the entry point of the site language.
 
-.. seealso::
+..  seealso::
 
     Take a look at :ref:`sitemap-providers` to learn how the extension
     internally evaluates the site configuration values to determine the

--- a/Documentation/Contributing/Index.rst
+++ b/Documentation/Contributing/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _contributing:
+..  _contributing:
 
 ============
 Contributing
@@ -16,7 +16,7 @@ To ensure the stability and cleanliness of the code, various code
 quality tools are used and most components are covered with test
 cases.
 
-.. _create-an-issue-first:
+..  _create-an-issue-first:
 
 Create an issue first
 =====================
@@ -27,53 +27,53 @@ GitHub: https://github.com/eliashaeussler/typo3-warming/issues
 Also, please check if there is already an issue on the topic you want
 to address.
 
-.. _contribution-workflow:
+..  _contribution-workflow:
 
 Contribution workflow
 =====================
 
-.. note::
+..  note::
 
     This extension follows `Semantic Versioning <https://semver.org/>`__.
 
-.. _preparation:
+..  _preparation:
 
 Preparation
 -----------
 
 Clone the repository first:
 
-.. code-block:: bash
+..  code-block:: bash
 
     git clone https://github.com/eliashaeussler/typo3-warming.git
     cd typo3-warming
 
 Now install all Composer dependencies:
 
-.. code-block:: bash
+..  code-block:: bash
 
     composer install
 
 Next, install all Node dependencies:
 
-.. code-block:: bash
+..  code-block:: bash
 
     yarn --cwd Resources/Private/Frontend
 
-.. _check-code-quality:
+..  _check-code-quality:
 
 Check code quality
 ------------------
 
-.. image:: https://github.com/eliashaeussler/typo3-warming/actions/workflows/cgl.yaml/badge.svg
+..  image:: https://github.com/eliashaeussler/typo3-warming/actions/workflows/cgl.yaml/badge.svg
     :target: https://github.com/eliashaeussler/typo3-warming/actions/workflows/cgl.yaml
 
-.. _cgl-typo3:
+..  _cgl-typo3:
 
 TYPO3
 ~~~~~
 
-.. code-block:: bash
+..  code-block:: bash
 
     # Run all linters
     composer lint
@@ -90,12 +90,12 @@ TYPO3
     # Run PHP static code analysis
     composer sca
 
-.. _cgl-frontend:
+..  _cgl-frontend:
 
 Frontend
 ~~~~~~~~
 
-.. code-block:: bash
+..  code-block:: bash
 
     # Run all linters
     yarn --cwd Resources/Private/Frontend lint
@@ -109,20 +109,20 @@ Frontend
     yarn --cwd Resources/Private/Frontend lint:ts
     yarn --cwd Resources/Private/Frontend lint:ts:fix
 
-.. _run-tests:
+..  _run-tests:
 
 Run tests
 ---------
 
-.. image:: https://github.com/eliashaeussler/typo3-warming/actions/workflows/tests.yaml/badge.svg
+..  image:: https://github.com/eliashaeussler/typo3-warming/actions/workflows/tests.yaml/badge.svg
     :target: https://github.com/eliashaeussler/typo3-warming/actions/workflows/tests.yaml
 
-.. image:: https://codecov.io/gh/eliashaeussler/typo3-warming/branch/main/graph/badge.svg?token=7M3UXACCKA
+..  image:: https://codecov.io/gh/eliashaeussler/typo3-warming/branch/main/graph/badge.svg?token=7M3UXACCKA
     :target: https://codecov.io/gh/eliashaeussler/typo3-warming
 
-.. rst-class:: mt-3
+..  rst-class:: mt-3
 
-.. code-block:: bash
+..  code-block:: bash
 
     # Run tests
     composer test
@@ -132,12 +132,12 @@ Run tests
 
 The code coverage reports will be stored in :file:`.Build/log/coverage`.
 
-.. _build-documentation:
+..  _build-documentation:
 
 Build documentation
 -------------------
 
-.. code-block:: bash
+..  code-block:: bash
 
     # Rebuild and open documentation
     composer docs
@@ -150,7 +150,7 @@ Build documentation
 
 The built docs will be stored in :file:`.Build/docs`.
 
-.. _pull-request:
+..  _pull-request:
 
 Pull Request
 ------------

--- a/Documentation/DeveloperCorner/AccessUtility.rst
+++ b/Documentation/DeveloperCorner/AccessUtility.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _access-utility:
+..  _access-utility:
 
 ===============
 `AccessUtility`
@@ -30,8 +30,8 @@ caches of specific sites or pages.
         :param TYPO3\\CMS\\Core\\Site\\Entity\\Site $site: The site to be checked.
         :param int $languageId: Optional language ID to be included in the check.
 
-.. seealso::
+..  seealso::
 
     View the sources on GitHub:
 
-    - `AccessUtility <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Utility/AccessUtility.php>`__
+    -   `AccessUtility <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Utility/AccessUtility.php>`__

--- a/Documentation/DeveloperCorner/Caching.rst
+++ b/Documentation/DeveloperCorner/Caching.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _caching:
+..  _caching:
 
 =======
 Caching
@@ -32,8 +32,8 @@ to a filesystem cached located at :file:`var/cache/code/core/tx_warming.php`.
 
         :param EliasHaeussler\\Typo3Warming\\Sitemap\\SiteAwareSitemap $sitemap: The located sitemap to be cached.
 
-.. seealso::
+..  seealso::
 
     View the sources on GitHub:
 
-    - `CacheManager <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Cache/CacheManager.php>`__
+    -   `CacheManager <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Cache/CacheManager.php>`__

--- a/Documentation/DeveloperCorner/ConfigurationAPI.rst
+++ b/Documentation/DeveloperCorner/ConfigurationAPI.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _configuration-api:
+..  _configuration-api:
 
 =================
 Configuration API
@@ -58,8 +58,8 @@ an appropriate class method.
 
         :returntype: array
 
-.. seealso::
+..  seealso::
 
     View the sources on GitHub:
 
-    - `Configuration <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Configuration/Configuration.php>`__
+    -   `Configuration <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Configuration/Configuration.php>`__

--- a/Documentation/DeveloperCorner/Crawlers.rst
+++ b/Documentation/DeveloperCorner/Crawlers.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _crawlers:
+..  _crawlers:
 
 ========
 Crawlers
@@ -35,7 +35,7 @@ implement a custom crawler on this page.
 
         :returns: A list of :php:class:`EliasHaeussler\\CacheWarmup\\CrawlingState` instances
 
-.. _default-crawlers:
+..  _default-crawlers:
 
 Default crawlers
 ================
@@ -58,12 +58,12 @@ toolbar item in the backend. Alternatively, a command
 `warming:showuseragent` is available which can be used to read the
 current `User-Agent` header.
 
-.. _implement-a-custom-crawler:
+..  _implement-a-custom-crawler:
 
 Implement a custom crawler
 ==========================
 
-.. _available-interfaces:
+..  _available-interfaces:
 
 Available interfaces
 --------------------
@@ -78,7 +78,7 @@ also a
 that redirects user-oriented output to an instance of
 :php:interface:`Symfony\\Component\\Console\\Output\\OutputInterface`.
 
-.. _configurable-crawlers:
+..  _configurable-crawlers:
 
 Configurable crawlers
 ---------------------
@@ -88,33 +88,33 @@ crawlers can also implement the
 :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`,
 allowing users to configure warmup requests themselves.
 
-.. seealso::
+..  seealso::
 
     `Feature #59 - Introduce configurable crawlers <https://github.com/eliashaeussler/cache-warmup/pull/59>`__
     of `eliashaeussler/cache-warmup` library
 
-.. _steps-to-implement-a-new-crawler:
+..  _steps-to-implement-a-new-crawler:
 
 Steps to implement a new crawler
 --------------------------------
 
-.. rst-class:: bignums
+..  rst-class:: bignums
 
 1.  Create a new crawler
 
     The new crawler must implement one of the following interfaces:
 
-    - :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\CrawlerInterface`
-    - :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\VerboseCrawlerInterface`
-    - :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`
+    -   :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\CrawlerInterface`
+    -   :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\VerboseCrawlerInterface`
+    -   :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`
 
-    .. tip::
+    ..  tip::
 
         This extension provides some additional traits which you can
         use for your new crawler:
 
-        - :php:trait:`EliasHaeussler\\Typo3Warming\\Crawler\\RequestAwareTrait`
-        - :php:trait:`EliasHaeussler\\Typo3Warming\\Crawler\\UseAgentTrait`
+        -   :php:trait:`EliasHaeussler\\Typo3Warming\\Crawler\\RequestAwareTrait`
+        -   :php:trait:`EliasHaeussler\\Typo3Warming\\Crawler\\UseAgentTrait`
 
 2.  Configure the new crawler
 

--- a/Documentation/DeveloperCorner/Index.rst
+++ b/Documentation/DeveloperCorner/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _developer-corner:
+..  _developer-corner:
 
 ================
 Developer corner
@@ -11,7 +11,7 @@ with custom implementations. This section provides an insight into
 which development options are available and how these can be integrated
 into the cache warmup process.
 
-.. toctree::
+..  toctree::
     :maxdepth: 3
 
     Crawlers

--- a/Documentation/DeveloperCorner/SitemapProviders.rst
+++ b/Documentation/DeveloperCorner/SitemapProviders.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _sitemap-providers:
+..  _sitemap-providers:
 
 =================
 Sitemap providers
@@ -33,21 +33,21 @@ priority) to localize XML sitemaps according to certain criteria.
 
         :returntype: int
 
-.. _default-providers:
+..  _default-providers:
 
 Default providers
 =================
 
 By default, the path to an XML sitemap is determined in three steps:
 
-.. rst-class:: bignums
+..  rst-class:: bignums
 
 1.  Site configuration
 
     Within the Sites module, one can explicitly define the path to
     the XML sitemap of a site.
 
-    .. image:: ../Images/site-configuration.png
+    ..  image:: ../Images/site-configuration.png
         :alt: Configuration of XML sitemap path within the Sites module
 
 2.  `robots.txt`
@@ -56,12 +56,12 @@ By default, the path to an XML sitemap is determined in three steps:
     `robots.txt` file is parsed for a valid `Sitemap` specification.
     Read more at `sitemaps.org <https://www.sitemaps.org/protocol.html#submit_robots>`__.
 
-    .. note::
+    ..  note::
         Only the first occurrence will be respected. In the following
         example, the resulting sitemap is
         `https://www.example.com/our-sitemap.xml`.
 
-        .. code-block:: none
+        ..  code-block:: none
             :emphasize-lines: 3
 
             User-agent: *
@@ -74,7 +74,7 @@ By default, the path to an XML sitemap is determined in three steps:
     If none of the above methods are successful, the default path
     `sitemap.xml` is used.
 
-.. _implement-a-custom-provider:
+..  _implement-a-custom-provider:
 
 Implement a custom provider
 ===========================
@@ -99,10 +99,10 @@ The order of the providers provided by default is as follows:
 Once your custom provider is ready, make sure to clear the DI
 caches in order to rebuild the service container properly.
 
-.. seealso::
+..  seealso::
     View the sources on GitHub:
 
-    - `ProviderInterface <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/ProviderInterface.php>`__
-    - `SiteProvider <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/SiteProvider.php>`__
-    - `RobotsTxtProvider <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/RobotsTxtProvider.php>`__
-    - `DefaultProvider <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/DefaultProvider.php>`__
+    -   `ProviderInterface <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/ProviderInterface.php>`__
+    -   `SiteProvider <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/SiteProvider.php>`__
+    -   `RobotsTxtProvider <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/RobotsTxtProvider.php>`__
+    -   `DefaultProvider <https://github.com/eliashaeussler/typo3-warming/blob/main/Classes/Sitemap/Provider/DefaultProvider.php>`__

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,17 +1,17 @@
-.. This is 'Includes.rst.txt'. It is included at the very top of each and
-   every ReST source file in THIS documentation project (= manual).
+..  This is 'Includes.rst.txt'. It is included at the very top of each and
+    every ReST source file in THIS documentation project (= manual).
 
-.. role:: aspect (emphasis)
-.. role:: html(code)
-.. role:: js(code)
-.. role:: php(code)
-.. role:: sep (strong)
-.. role:: sql(code)
-.. role:: typoscript(code)
-.. role:: yaml(code)
+..  role:: aspect (emphasis)
+..  role:: html(code)
+..  role:: js(code)
+..  role:: php(code)
+..  role:: sep (strong)
+..  role:: sql(code)
+..  role:: typoscript(code)
+..  role:: yaml(code)
 
-.. role:: ts(typoscript)
-   :class: typoscript
+..  role:: ts(typoscript)
+    :class: typoscript
 
-.. default-role:: code
-.. highlight:: php
+..  default-role:: code
+..  highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,17 +1,17 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _start:
+..  _start:
 
 =============================================
 Cache warmup of pages located in XML sitemaps
 =============================================
 
-.. rst-class:: horizbuttons-tip-m
+..  rst-class:: horizbuttons-tip-m
 
-- :ref:`console-commands`
-- :ref:`backend-toolbar`
-- :ref:`using-the-api`
-- :ref:`Custom crawlers <implement-a-custom-crawler>`
+-   :ref:`console-commands`
+-   :ref:`backend-toolbar`
+-   :ref:`using-the-api`
+-   :ref:`Custom crawlers <implement-a-custom-crawler>`
 
 :Extension key:
     `warming <https://extensions.typo3.org/extension/warming>`__
@@ -43,7 +43,7 @@ command. It supports multiple languages and custom crawler implementations.
 
 **Table of Contents**
 
-.. toctree::
+..  toctree::
     :maxdepth: 3
 
     Introduction/Index
@@ -53,7 +53,7 @@ command. It supports multiple languages and custom crawler implementations.
     DeveloperCorner/Index
     Contributing/Index
 
-.. toctree::
+..  toctree::
     :hidden:
 
     Sitemap

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,34 +1,34 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _installation:
+..  _installation:
 
 ============
 Installation
 ============
 
-.. _requirements:
+..  _requirements:
 
 Requirements
 ============
 
-* PHP 7.1 - 8.1
-* TYPO3 10.4 LTS - 11.5 LTS
+-   PHP 7.1 - 8.1
+-   TYPO3 10.4 LTS - 11.5 LTS
 
-.. _steps:
+..  _steps:
 
 Installation
 ============
 
 Require the extension via Composer (recommended):
 
-.. code-block:: bash
+..  code-block:: bash
 
     composer require eliashaeussler/typo3-warming
 
 Or download it from the
 `TYPO3 extension repository <https://extensions.typo3.org/extension/warming>`__.
 
-.. _version-matrix:
+..  _version-matrix:
 
 Version matrix
 ==============

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,12 +1,12 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _introduction:
+..  _introduction:
 
 ============
 Introduction
 ============
 
-.. _what-it-does:
+..  _what-it-does:
 
 What does it do?
 ================
@@ -14,16 +14,16 @@ What does it do?
 The extension provides a service to warm up Frontend caches based on an XML
 sitemap. Cache warmup can be triggered in various ways:
 
-- Via the :ref:`TYPO3 backend <backend-toolbar>`
-- Using a :ref:`console command <console-commands>`
-- Directly with the :ref:`PHP API <using-the-api>`
+-   Via the :ref:`TYPO3 backend <backend-toolbar>`
+-   Using a :ref:`console command <console-commands>`
+-   Directly with the :ref:`PHP API <using-the-api>`
 
 It supports multiple languages and custom crawler implementations.
 Under the hood, the extension makes use of the
 `eliashaeussler/cache-warmup <https://github.com/eliashaeussler/cache-warmup>`__
 library which provides the core cache warmup implementation.
 
-.. _features:
+..  _features:
 
 Features
 ========
@@ -38,7 +38,7 @@ Features
 -   :ref:`Console commands <console-commands>`
 -   Compatible with TYPO3 10.4 LTS and 11.5 LTS
 
-.. _support:
+..  _support:
 
 Support
 =======
@@ -48,7 +48,7 @@ There are several ways to get support for this extension:
 * Slack: https://typo3.slack.com/archives/C0400CSGWAY
 * GitHub: https://github.com/eliashaeussler/typo3-warming/issues
 
-.. _license:
+..  _license:
 
 License
 =======

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -1,9 +1,9 @@
 :template: sitemap.html
 
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
 =======
 Sitemap
 =======
 
-.. The sitemap.html template will insert here the page tree automatically.
+..  The sitemap.html template will insert here the page tree automatically.

--- a/Documentation/Usage/BackendToolbar.rst
+++ b/Documentation/Usage/BackendToolbar.rst
@@ -1,12 +1,12 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _backend-toolbar:
+..  _backend-toolbar:
 
 ===============
 Backend toolbar
 ===============
 
-.. note::
+..  note::
 
     The toolbar item is only visible for admins and permitted users.
     Read how to give non-admin users access to the toolbar item at
@@ -17,10 +17,10 @@ backend should appear. You can click on the toolbar item to get a list
 of all sites. If a site does not provide an XML sitemap, it cannot be
 used to warm up caches.
 
-.. image:: ../Images/toolbar-item.png
+..  image:: ../Images/toolbar-item.png
     :alt: Cache warmup toolbar item within the TYPO3 backend
 
-.. tip::
+..  tip::
 
     The toolbar item additionally outputs information about the
     `User-Agent` header used during the cache warmup. By clicking on

--- a/Documentation/Usage/ConsoleCommands.rst
+++ b/Documentation/Usage/ConsoleCommands.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _console-commands:
+..  _console-commands:
 
 ================
 Console commands
@@ -8,7 +8,7 @@ Console commands
 
 The extension provides the following console commands:
 
-.. _warming-cachewarmup:
+..  _warming-cachewarmup:
 
 `warming:cachewarmup`
 =====================
@@ -16,27 +16,27 @@ The extension provides the following console commands:
 A command to trigger cache warmup of single pages and/or whole sites
 using their XML sitemaps.
 
-.. important::
+..  important::
 
     You must pass at least the `--pages` or `--sites` command option.
 
-.. tabs::
+..  tabs::
 
-    .. group-tab:: Composer-based installation
+    ..  group-tab:: Composer-based installation
 
-        .. code-block:: bash
+        ..  code-block:: bash
 
             vendor/bin/typo3 warming:cachewarmup
 
-    .. group-tab:: Legacy installation
+    ..  group-tab:: Legacy installation
 
-        .. code-block:: bash
+        ..  code-block:: bash
 
             typo3/sysext/core/bin/typo3 warming:cachewarmup
 
 The following command options are available:
 
-.. confval:: -p|--pages
+..  confval:: -p|--pages
 
     :Required: false
     :type: integer
@@ -50,23 +50,23 @@ The following command options are available:
 
     Example:
 
-    .. tabs::
+    ..  tabs::
 
-        .. group-tab:: Composer-based installation
+        ..  group-tab:: Composer-based installation
 
-            .. code-block:: bash
+            ..  code-block:: bash
 
                 vendor/bin/typo3 warming:cachewarmup -p 1 -p 2 -p 3
                 vendor/bin/typo3 warming:cachewarmup -p 1,2,3
 
-       .. group-tab:: Legacy installation
+        ..  group-tab:: Legacy installation
 
-            .. code-block:: bash
+            ..  code-block:: bash
 
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -p 1 -p 2 -p 3
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -p 1,2,3
 
-.. confval:: -s|--sites
+..  confval:: -s|--sites
 
     :Required: false
     :type: integer or string (site identifier)
@@ -79,23 +79,23 @@ The following command options are available:
 
     Example:
 
-    .. tabs::
+    ..  tabs::
 
-        .. group-tab:: Composer-based installation
+        ..  group-tab:: Composer-based installation
 
-            .. code-block:: bash
+            ..  code-block:: bash
 
                 vendor/bin/typo3 warming:cachewarmup -s my-cool-site
                 vendor/bin/typo3 warming:cachewarmup -s 1
 
-        .. group-tab:: Legacy installation
+        ..  group-tab:: Legacy installation
 
-            .. code-block:: bash
+            ..  code-block:: bash
 
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -s my-cool-site
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -s 1
 
-.. confval:: -l|--languages
+..  confval:: -l|--languages
 
     :Required: false
     :type: integer
@@ -108,23 +108,23 @@ The following command options are available:
 
     Example:
 
-    .. tabs::
+    ..  tabs::
 
-        .. group-tab:: Composer-based installation
+        ..  group-tab:: Composer-based installation
 
-            .. code-block:: bash
+            ..  code-block:: bash
 
                 vendor/bin/typo3 warming:cachewarmup -l 0 -l 1
                 vendor/bin/typo3 warming:cachewarmup -l 0,1
 
-        .. group-tab:: Legacy installation
+        ..  group-tab:: Legacy installation
 
-            .. code-block:: bash
+            ..  code-block:: bash
 
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -l 0 -l 1
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -l 0,1
 
-.. confval:: --limit
+..  confval:: --limit
 
     :Required: false
     :type: integer
@@ -136,7 +136,7 @@ The following command options are available:
     from :ref:`extension configuration <extension-configuration>` is
     used.
 
-.. confval:: -x|--strict
+..  confval:: -x|--strict
 
     :Required: false
     :type: boolean
@@ -146,7 +146,7 @@ The following command options are available:
     Exit with a non-zero status code in case cache warmup fails or
     errors occur during cache warmup.
 
-.. _warming-showuseragent:
+..  _warming-showuseragent:
 
 `warming:showuseragent`
 =======================
@@ -154,20 +154,20 @@ The following command options are available:
 A command that shows the custom `User-Agent` header that is used for
 cache warmup requests by default crawlers.
 
-.. note::
+..  note::
 
     This command is not :ref:`schedulable <t3coreapi:schedulable>`.
 
-.. tabs::
+..  tabs::
 
-    .. group-tab:: Composer-based installation
+    ..  group-tab:: Composer-based installation
 
-        .. code-block:: bash
+        ..  code-block:: bash
 
             vendor/bin/typo3 warming:showuseragent
 
-    .. group-tab:: Legacy installation
+    ..  group-tab:: Legacy installation
 
-        .. code-block:: bash
+        ..  code-block:: bash
 
             typo3/sysext/core/bin/typo3 warming:showuseragent

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,12 +1,12 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _usage:
+..  _usage:
 
 =====
 Usage
 =====
 
-.. note::
+..  note::
 
     Currently it is not possible to use more than one XML sitemap per
     site and language for the cache warmup.
@@ -16,7 +16,7 @@ Basically the cache warming can be executed in two different modes: Either
 for whole sites based on their XML sitemap or for single pages based on
 their page ID.
 
-.. toctree::
+..  toctree::
     :maxdepth: 3
 
     BackendToolbar

--- a/Documentation/Usage/PageTree.rst
+++ b/Documentation/Usage/PageTree.rst
@@ -1,12 +1,12 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _page-tree:
+..  _page-tree:
 
 =========
 Page tree
 =========
 
-.. note::
+..  note::
 
     The context menu items are only visible for admins and permitted
     users. Read how to give non-admin users access to the context menu
@@ -15,10 +15,10 @@ Page tree
 Next to the item in the backend toolbar, one can also trigger cache
 warmup using the context menu of pages inside the page tree.
 
-.. image:: ../Images/context-menu.png
+..  image:: ../Images/context-menu.png
     :alt: Cache warmup context meu items within the page tree
 
-.. note::
+..  note::
 
     The option :guilabel:`Warmup cache for this page` is available for
     all pages whereas the option :guilabel:`Warmup all caches` is only

--- a/Documentation/Usage/UsingTheAPI.rst
+++ b/Documentation/Usage/UsingTheAPI.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _using-the-api:
+..  _using-the-api:
 
 =============
 Using the API
@@ -53,7 +53,7 @@ warmup directly in PHP code.
         :param string|EliasHaeussler\\CacheWarmup\\Crawler\\CrawlerInterface $crawler: The crawler to use for cache warmup.
         :returns: The service object (fluent setter).
 
-.. _api-example:
+..  _api-example:
 
 Example
 =======

--- a/Documentation/genindex.rst
+++ b/Documentation/genindex.rst
@@ -1,7 +1,7 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
 =====
 Index
 =====
 
-.. Sphinx will insert here the general index automatically.
+..  Sphinx will insert here the general index automatically.


### PR DESCRIPTION
This PR streamlines indentation across the whole documentation to match TYPO3 coding standards (4 spaces).