### PR TITLE
[FEATURE] Allow configuration of recursively accessible pages

### DIFF
--- a/Documentation/Configuration/Permissions.rst
+++ b/Documentation/Configuration/Permissions.rst
@@ -35,13 +35,14 @@ configuration to the :typoscript:`options.cacheWarmup` User TSconfig:
     :type: string (comma-separated list)
 
     Provide a comma-separated list of pages. Those pages can
-    then be warmed by the backend user.
+    then be warmed by the backend user. Pages can be suffixed
+    by a `+` sign to recursively include all subpages.
 
     Example:
 
     ..  code-block:: typoscript
 
-        options.cacheWarmup.allowedPages = 1,2,3
+        options.cacheWarmup.allowedPages = 1,2,3+
 
 ..  seealso::
 


### PR DESCRIPTION
User TSconfig for cache warmup may now contain recursively accessible pages. For this, a plus sign (`+`) must be added to a page id to allow cache warmup for all subpages of this page.

Example:

```
options.cacheWarmup.allowedPages = 1,72+
```

In this example, the pages with 1 and 72 as well as all subpages of page 72 can be warmed up.