### PR TITLE
[BUGFIX] Support query string in XML sitemap path

### DIFF
--- a/Classes/Sitemap/Provider/AbstractProvider.php
+++ b/Classes/Sitemap/Provider/AbstractProvider.php
@@ -40,6 +40,11 @@ abstract class AbstractProvider implements ProviderInterface
         $baseUrl = $siteLanguage !== null ? $siteLanguage->getBase() : $site->getBase();
         $fullPath = rtrim($baseUrl->getPath(), '/') . '/' . ltrim($path, '/');
 
+        if (str_contains($fullPath, '?')) {
+            [$fullPath, $queryString] = explode('?', $fullPath, 2);
+            $baseUrl = $baseUrl->withQuery($queryString);
+        }
+
         return $baseUrl->withPath($fullPath);
     }
 }

--- a/Tests/Unit/Sitemap/Provider/SiteProviderTest.php
+++ b/Tests/Unit/Sitemap/Provider/SiteProviderTest.php
@@ -58,31 +58,55 @@ final class SiteProviderTest extends UnitTestCase
 
     /**
      * @test
+     * @dataProvider getReturnsSitemapWithUrlPathFromSiteDataProvider
      */
-    public function getReturnsSitemapWithUrlPathFromSite(): void
+    public function getReturnsSitemapWithUrlPathFromSite(string $path, string $expected): void
     {
         $site = new Site('foo', 1, [
             'base' => 'https://www.example.com/',
-            'xml_sitemap_path' => 'baz.xml',
+            'xml_sitemap_path' => $path,
         ]);
-        $expected = new SiteAwareSitemap(new Uri('https://www.example.com/baz.xml'), $site);
 
-        self::assertEquals($expected, $this->subject->get($site));
+        self::assertEquals(
+            new SiteAwareSitemap(new Uri($expected), $site),
+            $this->subject->get($site)
+        );
     }
 
     /**
      * @test
+     * @dataProvider getReturnsSitemapWithUrlPathFromSiteLanguageDataProvider
      */
-    public function getReturnsSitemapWithUrlPathFromSiteLanguage(): void
+    public function getReturnsSitemapWithUrlPathFromSiteLanguage(string $path, string $expected): void
     {
         $site = new Site('foo', 1, [
             'base' => 'https://www.example.com/',
         ]);
         $siteLanguage = new SiteLanguage(1, 'de_DE.UTF-8', new Uri('https://www.example.com/de'), [
-            'xml_sitemap_path' => 'baz.xml',
+            'xml_sitemap_path' => $path,
         ]);
-        $expected = new SiteAwareSitemap(new Uri('https://www.example.com/de/baz.xml'), $site, $siteLanguage);
 
-        self::assertEquals($expected, $this->subject->get($site, $siteLanguage));
+        self::assertEquals(
+            new SiteAwareSitemap(new Uri($expected), $site, $siteLanguage),
+            $this->subject->get($site, $siteLanguage)
+        );
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public function getReturnsSitemapWithUrlPathFromSiteDataProvider(): \Generator
+    {
+        yield 'path only' => ['baz.xml', 'https://www.example.com/baz.xml'];
+        yield 'path with query string' => ['baz.xml?foo=baz', 'https://www.example.com/baz.xml?foo=baz'];
+    }
+
+    /**
+     * @return \Generator<string, array{string, string}>
+     */
+    public function getReturnsSitemapWithUrlPathFromSiteLanguageDataProvider(): \Generator
+    {
+        yield 'path only' => ['baz.xml', 'https://www.example.com/de/baz.xml'];
+        yield 'path with query string' => ['baz.xml?foo=baz', 'https://www.example.com/de/baz.xml?foo=baz'];
     }
 }


### PR DESCRIPTION
XML sitemap paths may now contain a query string. This comes in handy if – for example – only a specific sitemap should be crawled rather than all sitemaps.