### PR TITLE
[FEATURE] Add global feature toggles for context menu and toolbar

### DIFF
--- a/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
+++ b/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
@@ -94,6 +94,11 @@ final class CacheWarmupProvider extends PageProvider
 
     protected function canRender(string $itemName, string $type): bool
     {
+        // Early return if cache warmup from page tree is disabled globally
+        if (!$this->configuration->isEnabledInPageTree()) {
+            return false;
+        }
+
         // Pseudo items (such as dividers) are always renderable
         if ($type !== 'item') {
             return true;

--- a/Classes/Backend/ToolbarItems/CacheWarmupToolbarItem.php
+++ b/Classes/Backend/ToolbarItems/CacheWarmupToolbarItem.php
@@ -86,6 +86,11 @@ final class CacheWarmupToolbarItem implements ToolbarItemInterface
 
     public function checkAccess(): bool
     {
+        // Early return if cache warmup from backend toolbar is disabled globally
+        if (!$this->configuration->isEnabledInToolbar()) {
+            return false;
+        }
+
         foreach ($this->siteFinder->getAllSites() as $site) {
             if (AccessUtility::canWarmupCacheOfSite($site)) {
                 return true;

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -149,6 +149,28 @@ final class Configuration
         }
     }
 
+    public function isEnabledInPageTree(): bool
+    {
+        try {
+            $enablePageTree = $this->configuration->get(Extension::KEY, 'enablePageTree');
+
+            return (bool)$enablePageTree;
+        } catch (Exception $e) {
+            return true;
+        }
+    }
+
+    public function isEnabledInToolbar(): bool
+    {
+        try {
+            $enableToolbar = $this->configuration->get(Extension::KEY, 'enableToolbar');
+
+            return (bool)$enableToolbar;
+        } catch (Exception $e) {
+            return true;
+        }
+    }
+
     /**
      * @return list<int>
      */

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -72,6 +72,16 @@ The extension currently provides the following configuration options:
     :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`.
     For more information read :ref:`configurable-crawlers`.
 
+..  _extconf-enablePageTree:
+
+..  confval:: enablePageTree
+
+    :type: boolean
+    :Default: 1
+
+    Enable cache warmup in the :ref:`page tree <page-tree>` context menu. This affects
+    all users, including administrators.
+
 ..  _extconf-supportedDoktypes:
 
 ..  confval:: supportedDoktypes
@@ -83,3 +93,13 @@ The extension currently provides the following configuration options:
     :ref:`page tree <page-tree>` context menu. Defaults to default pages with doktype
     :php:`1` only. If your project implements custom doktypes, you can add them here to
     support cache warmup from the context menu.
+
+..  _extconf-enableToolbar:
+
+..  confval:: enableToolbar
+
+    :type: boolean
+    :Default: 1
+
+    Enable cache warmup in the :ref:`backend toolbar <backend-toolbar>`. This affects
+    all users, including administrators.

--- a/Documentation/Configuration/Permissions.rst
+++ b/Documentation/Configuration/Permissions.rst
@@ -6,6 +6,12 @@
 Permissions
 ===========
 
+..  note::
+
+    Cache warmup can also be enabled or disabled globally. Check
+    out the extension configuration for :ref:`page tree <extconf-enablePageTree>`
+    and :ref:`backend toolbar <extconf-enableToolbar>`.
+
 Administrators are able to run cache warmup for all available
 sites and pages. All other users are by default not allowed to
 run those tasks. Thus, they cannot see both the cache warmup

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,5 +13,11 @@ verboseCrawler = EliasHaeussler\Typo3Warming\Crawler\OutputtingUserAgentCrawler
 # cat=basic/35; type=string; label=Verbose crawler options (JSON-encoded string):Provide crawler options for the verbose crawler. Applies only if the verbose crawler implements the interface "EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface".
 verboseCrawlerOptions =
 
-# cat=pageTree/10; type=string; label=Supported doktypes in page tree:Provide a comma-separated list of doktypes for which cache warmup should be available in the page tree context menu.
+# cat=pageTree/10; type=boolean; label=Enable cache warmup from page tree
+enablePageTree = 1
+
+# cat=pageTree/20; type=string; label=Supported doktypes in page tree:Provide a comma-separated list of doktypes for which cache warmup should be available in the page tree context menu.
 supportedDoktypes = 1
+
+# cat=toolbar/10; type=boolean; label=Enable cache warmup from backend toolbar
+enableToolbar = 1


### PR DESCRIPTION
Cache warmup from context menu and backend toolbar can now be disabled for all users. For this, two new extension configurations were added:

- `enablePageTree`
- `enableToolbar`

The `Configuration` class has been extended to reflect the new configuration values:

- `EliasHaeussler\Typo3Warming\Configuration\Configuration::isEnabledInPageTree()`
- `EliasHaeussler\Typo3Warming\Configuration\Configuration::isEnabledInToolbar()`