### PR TITLE
[TASK] Exclude `CODE_OF_CONDUCT.md` from dist files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 /.gitattributes              export-ignore
 /.gitignore                  export-ignore
 /.php-cs-fixer.php           export-ignore
+/CODE_OF_CONDUCT.md          export-ignore
 /codecov.yml                 export-ignore
 /CODEOWNERS                  export-ignore
 /dependency-checker.json     export-ignore

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -37,6 +37,7 @@ return [
     ],
     'files' => [
         'DS_Store',
+        'CODE_OF_CONDUCT.md',
         'codecov.yml',
         'CODEOWNERS',
         'composer.lock',


### PR DESCRIPTION
The `CODE_OF_CONDUCT.md` file is only relevant when contributing to this project.