### PR TITLE
[TASK] Use Renovate TYPO3 extension preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"local>eliashaeussler/renovate-config"
-	],
-	"composerIgnorePlatformReqs": [
-		"ext-intl"
-	],
-	"packageRules": [
-		{
-			"extends": [
-				":automergeDisabled"
-			],
-			"matchFiles": [
-				"Resources/Private/Libs/Build/composer.json"
-			],
-			"matchDepNames": [
-				"php"
-			]
-		}
+		"local>eliashaeussler/renovate-config:typo3-extension"
 	]
 }


### PR DESCRIPTION
This PR switches the used Renovate preset from `default.json` to `typo3-extension.json`, see eliashaeussler/renovate-config#24.