### PR TITLE
[BUGFIX] Properly check for hidden pages in `AccessUtility`

### DIFF
--- a/Classes/Utility/AccessUtility.php
+++ b/Classes/Utility/AccessUtility.php
@@ -55,10 +55,6 @@ final class AccessUtility
     {
         $backendUser = Utility\BackendUtility::getBackendUser();
 
-        if ($languageId === null && $backendUser->isAdmin()) {
-            return true;
-        }
-
         // Fetch record and record localization (if language is given and is not default language),
         // additionally check for available pages by adding hidden=0 as additional WHERE clause
         $record = Backend\Utility\BackendUtility::getRecord('pages', $pageId, '*', 'hidden = 0');
@@ -69,6 +65,11 @@ final class AccessUtility
         // Early return if record is inaccessible
         if (!\is_array($record) || $record === []) {
             return false;
+        }
+
+        // Early return if backend user has admin privileges
+        if ($backendUser->isAdmin()) {
+            return true;
         }
 
         // Select first record inside list of records which is potentially returned by


### PR DESCRIPTION
This PR hardens the page permission check for pages in `AccessUtility`. If any page is hidden, even users with admin privileges can no longer warmup those pages.