### PR TITLE
[BUGFIX] Don't render button to sites module for non-admins

### DIFF
--- a/Classes/Controller/FetchSitesController.php
+++ b/Classes/Controller/FetchSitesController.php
@@ -71,7 +71,7 @@ final class FetchSitesController
         }
 
         return $this->responseFactory->htmlTemplate('Modal/SitesModal', [
-            'siteGroups' => $siteGroups,
+            'siteGroups' => array_filter($siteGroups),
             'userAgent' => $this->configuration->getUserAgent(),
             'configuration' => [
                 'limit' => $this->configuration->getLimit(),
@@ -88,7 +88,7 @@ final class FetchSitesController
      * @throws Exception\UnsupportedConfigurationException
      * @throws Exception\UnsupportedSiteException
      */
-    private function createSiteGroup(Core\Site\Entity\Site $site, array $page): ValueObject\Modal\SiteGroup
+    private function createSiteGroup(Core\Site\Entity\Site $site, array $page): ?ValueObject\Modal\SiteGroup
     {
         $items = [];
 
@@ -107,6 +107,11 @@ final class FetchSitesController
                 $siteLanguage === $site->getDefaultLanguage(),
                 $url,
             );
+        }
+
+        // Early return if no languages are available
+        if ($items === []) {
+            return null;
         }
 
         return new ValueObject\Modal\SiteGroup(

--- a/Resources/Private/Partials/Modal/Alert/NoSites.html
+++ b/Resources/Private/Partials/Modal/Alert/NoSites.html
@@ -12,11 +12,13 @@
     <f:translate key="LLL:EXT:warming/Resources/Private/Language/locallang.xlf:modal.alert.noSitesConfigured.message" />
 </p>
 
-<p>
-    <f:be.link route="site_configuration" class="btn btn-primary">
-        <c:icon identifier="actions-list" />
-        <f:translate key="LLL:EXT:warming/Resources/Private/Language/locallang.xlf:modal.alert.noSitesConfigured.button" />
-    </f:be.link>
-</p>
+<f:if condition="{isAdmin}">
+    <p>
+        <f:be.link route="site_configuration" class="btn btn-primary">
+            <c:icon identifier="actions-list" />
+            <f:translate key="LLL:EXT:warming/Resources/Private/Language/locallang.xlf:modal.alert.noSitesConfigured.button" />
+        </f:be.link>
+    </p>
+</f:if>
 
 </html>

--- a/Resources/Private/Templates/Modal/SitesModal.html
+++ b/Resources/Private/Templates/Modal/SitesModal.html
@@ -12,7 +12,7 @@
     </f:then>
     <f:else>
         <div class="tx-warming-alert-modal">
-            <f:render partial="Modal/Alert/NoSites" />
+            <f:render partial="Modal/Alert/NoSites" arguments="{isAdmin: isAdmin}" />
         </div>
     </f:else>
 </f:if>


### PR DESCRIPTION
When no sites are available for cache warmup, the cache warmup modal shows an appropriate notice together with a linked button to the sites module. However, this module is not accessible for non-admins and is now hidden for these users.