### PR TITLE
[FEATURE] Provide TypoScript configuration for Fluid templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,4 @@
 /phpunit.unit.xml            export-ignore
 /rector.php                  export-ignore
 /renovate.json               export-ignore
+/typoscript-lint.yml         export-ignore

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -47,6 +47,8 @@ jobs:
         run: composer lint:editorconfig
       - name: Lint PHP
         run: composer lint:php
+      - name: Lint TypoScript
+        run: composer lint:typoscript
 
       # SCA
       - name: SCA PHP

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -18,4 +18,5 @@ Learn what configuration options are available on the following pages:
 
     ExtensionConfiguration
     SiteConfiguration
+    TypoScriptConfiguration
     Permissions

--- a/Documentation/Configuration/TypoScriptConfiguration.rst
+++ b/Documentation/Configuration/TypoScriptConfiguration.rst
@@ -1,0 +1,42 @@
+..  include:: /Includes.rst.txt
+
+..  _typoscript-configuration:
+
+========================
+TypoScript configuration
+========================
+
+The following global TypoScript configuration is available:
+
+..  _typoscript-constants:
+
+Constants
+=========
+
+..  _typoscript-constants-view.templateRootPath:
+
+..  confval:: view.templateRootPath
+
+    :type: string
+    :Path: module.tx_warming
+
+    Additional path to template root used in Backend context. Within this
+    path, Fluid templates can be overwritten.
+
+    ..  seealso::
+
+        Read more in the :ref:`official documentation <t3tsref:tlo-module-properties-templateRootPaths>`.
+
+..  _typoscript-constants-view.partialRootPath:
+
+..  confval:: view.partialRootPath
+
+    :type: string
+    :Path: module.tx_warming
+
+    Additional path to template partials used in Backend context. Within
+    this path, Fluid partials can be overwritten.
+
+    ..  seealso::
+
+        Read more in the :ref:`official documentation <t3tsref:tlo-module-properties-partialRootPaths>`.

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
 		"eliashaeussler/typo3-codeception-helper": "^1.0",
 		"ergebnis/composer-normalize": "^2.30",
 		"helhum/typo3-console": "^8.0",
+		"helmich/typo3-typoscript-lint": "^3.1",
 		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan-symfony": "^1.3",
 		"phpunit/phpcov": "^9.0",
@@ -115,7 +116,8 @@
 		"fix": [
 			"@fix:composer",
 			"@fix:editorconfig",
-			"@fix:php"
+			"@fix:php",
+			"@fix:typoscript"
 		],
 		"fix:composer": [
 			"@composer normalize",
@@ -123,14 +125,17 @@
 		],
 		"fix:editorconfig": "@lint:editorconfig --fix",
 		"fix:php": "php-cs-fixer fix",
+		"fix:typoscript": "@lint:typoscript",
 		"lint": [
 			"@lint:composer",
 			"@lint:editorconfig",
-			"@lint:php"
+			"@lint:php",
+			"@lint:typoscript"
 		],
 		"lint:composer": "@fix:composer --dry-run",
 		"lint:editorconfig": "ec --finder-config .editorconfig-lint.php",
 		"lint:php": "@fix:php --dry-run",
+		"lint:typoscript": "typoscript-lint -c typoscript-lint.yml --fail-on-warnings",
 		"migration": [
 			"@migration:rector"
 		],

--- a/ext_typoscript_constants.typoscript
+++ b/ext_typoscript_constants.typoscript
@@ -1,0 +1,11 @@
+# customcategory=warming=Warming
+# customsubcategory=view=View
+
+module.tx_warming {
+  view {
+    # cat=warming/view/10; type=string; label=Path to template root
+    templateRootPath =
+    # cat=warming/view/20; type=string; label=Path to template partials
+    partialRootPath =
+  }
+}

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -1,0 +1,12 @@
+module.tx_warming {
+  view {
+    templateRootPaths {
+      0 = EXT:warming/Resources/Private/Templates/
+      10 = {$module.tx_warming.view.templateRootPath}
+    }
+    partialRootPaths {
+      0 = EXT:warming/Resources/Private/Partials/
+      10 = {$module.tx_warming.view.partialRootPath}
+    }
+  }
+}

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -56,5 +56,6 @@ return [
         'phpunit.functional.xml',
         'phpunit.unit.xml',
         'rector.php',
+        'typoscript-lint.yml',
     ],
 ];

--- a/typoscript-lint.yml
+++ b/typoscript-lint.yml
@@ -1,0 +1,20 @@
+paths:
+  - .
+filePatterns:
+  - "*.typoscript"
+  - "*.tsconfig"
+sniffs:
+  - class: Indentation
+    parameters:
+      useSpaces: true
+      indentPerLevel: 2
+      indentConditions: true
+  - class: DeadCode
+  - class: OperatorWhitespace
+  - class: RepeatingRValue
+    disabled: true
+  - class: DuplicateAssignment
+  - class: EmptySection
+  - class: NestingConsistency
+    parameters:
+      commonPathPrefixThreshold: 2


### PR DESCRIPTION
This PR introduces a global TypoScript configuration that allows to override Fluid templates used in EXT:warming. The following TypoScript constants are now available:

```
module.tx_warming {
  view {
    # cat=warming/view/10; type=string; label=Path to template root
    templateRootPath =
    # cat=warming/view/20; type=string; label=Path to template partials
    partialRootPath =
  }
}
```

Related: #174