### PR TITLE
[BUGFIX] Retry failed acceptance tests in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,10 @@ jobs:
 
       # Run tests
       - name: Run tests
-        run: ddev composer test
+        run: |
+          ddev composer test:acceptance || ddev composer test:acceptance -g failed
+          ddev composer test:functional
+          ddev composer test:unit
 
       # Save acceptance reports
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Acceptance tests may fail from time to time due to timeouts. With this PR, those failed tests are now retried one time in CI. This cannot be done for the coverage job as well as it would provide an incomplete coverage report.