### PR TITLE
[!!!][FEATURE] Support multiple sitemaps to be located

### DIFF
--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -334,10 +334,11 @@ final class WarmupCommand extends Console\Command\Command
                 }
 
                 foreach ($languageIds as $languageId) {
-                    $resolvedSitemaps[] = (string)$this->sitemapLocator->locateBySite(
-                        $site,
-                        $site->getLanguageById($languageId)
-                    )->getUri();
+                    $sitemaps = $this->sitemapLocator->locateBySite($site, $site->getLanguageById($languageId));
+
+                    foreach ($sitemaps as $sitemap) {
+                        $resolvedSitemaps[] = (string)$sitemap->getUri();
+                    }
                 }
             }
         }

--- a/Classes/Controller/FetchSitesController.php
+++ b/Classes/Controller/FetchSitesController.php
@@ -93,20 +93,22 @@ final class FetchSitesController
         $items = [];
 
         // Check all available languages for possible sitemaps
-        foreach ($this->sitemapLocator->locateAllBySite($site) as $sitemap) {
-            $siteLanguage = $sitemap->getSiteLanguage();
-            $url = null;
+        foreach ($this->sitemapLocator->locateAllBySite($site) as $i => $sitemaps) {
+            foreach ($sitemaps as $sitemap) {
+                $siteLanguage = $sitemap->getSiteLanguage();
+                $url = null;
 
-            // Check if sitemap is accessible
-            if ($this->sitemapLocator->siteContainsSitemap($site, $siteLanguage)) {
-                $url = (string)$sitemap->getUri();
+                // Check if sitemap exists
+                if ($this->sitemapLocator->sitemapExists($sitemap)) {
+                    $url = (string)$sitemap->getUri();
+                }
+
+                $items[] = new ValueObject\Modal\SiteGroupItem(
+                    $siteLanguage,
+                    $siteLanguage === $site->getDefaultLanguage(),
+                    $url,
+                );
             }
-
-            $items[] = new ValueObject\Modal\SiteGroupItem(
-                $siteLanguage,
-                $siteLanguage === $site->getDefaultLanguage(),
-                $url,
-            );
         }
 
         // Early return if no languages are available

--- a/Classes/Service/CacheWarmupService.php
+++ b/Classes/Service/CacheWarmupService.php
@@ -88,8 +88,8 @@ final class CacheWarmupService
         foreach ($sites as $siteWarmupRequest) {
             foreach ($siteWarmupRequest->getLanguageIds() as $languageId) {
                 $siteLanguage = $siteWarmupRequest->getSite()->getLanguageById($languageId);
-                $sitemap = $this->sitemapLocator->locateBySite($siteWarmupRequest->getSite(), $siteLanguage);
-                $cacheWarmer->addSitemaps($sitemap);
+                $sitemaps = $this->sitemapLocator->locateBySite($siteWarmupRequest->getSite(), $siteLanguage);
+                $cacheWarmer->addSitemaps($sitemaps);
             }
         }
 

--- a/Classes/Sitemap/Provider/DefaultProvider.php
+++ b/Classes/Sitemap/Provider/DefaultProvider.php
@@ -40,12 +40,14 @@ final class DefaultProvider implements Provider
     public function get(
         Core\Site\Entity\Site $site,
         Core\Site\Entity\SiteLanguage $siteLanguage = null,
-    ): ?Sitemap\SiteAwareSitemap {
-        return new Sitemap\SiteAwareSitemap(
+    ): array {
+        $sitemap = new Sitemap\SiteAwareSitemap(
             Utility\HttpUtility::getSiteUrlWithPath($site, self::DEFAULT_PATH, $siteLanguage),
             $site,
             $siteLanguage ?? $site->getDefaultLanguage(),
         );
+
+        return [$sitemap];
     }
 
     /**

--- a/Classes/Sitemap/Provider/PageTypeProvider.php
+++ b/Classes/Sitemap/Provider/PageTypeProvider.php
@@ -42,25 +42,26 @@ final class PageTypeProvider implements Provider
     public function get(
         Core\Site\Entity\Site $site,
         Core\Site\Entity\SiteLanguage $siteLanguage = null,
-    ): ?Sitemap\SiteAwareSitemap {
+    ): array {
         // Early return if EXT:seo is not installed
         if (!Core\Utility\ExtensionManagementUtility::isLoaded('seo')) {
-            return null;
+            return [];
         }
 
         $pageTypeMap = $site->getConfiguration()['routeEnhancers']['PageTypeSuffix']['map'] ?? null;
 
         // Early return if no page type map is configured
         if (!\is_array($pageTypeMap) || !\in_array(self::EXPECTED_PAGE_TYPE, $pageTypeMap, true)) {
-            return null;
+            return [];
         }
 
         $uri = $site->getRouter()->generateUri('/', [
             'type' => self::EXPECTED_PAGE_TYPE,
             '_language' => $siteLanguage,
         ]);
+        $sitemap = new Sitemap\SiteAwareSitemap($uri, $site, $siteLanguage ?? $site->getDefaultLanguage());
 
-        return new Sitemap\SiteAwareSitemap($uri, $site, $siteLanguage ?? $site->getDefaultLanguage());
+        return [$sitemap];
     }
 
     /**

--- a/Classes/Sitemap/Provider/Provider.php
+++ b/Classes/Sitemap/Provider/Provider.php
@@ -34,10 +34,13 @@ use TYPO3\CMS\Core;
  */
 interface Provider
 {
+    /**
+     * @return list<Sitemap\SiteAwareSitemap>
+     */
     public function get(
         Core\Site\Entity\Site $site,
         Core\Site\Entity\SiteLanguage $siteLanguage = null,
-    ): ?Sitemap\SiteAwareSitemap;
+    ): array;
 
     public static function getPriority(): int;
 }

--- a/Classes/Sitemap/Provider/SiteProvider.php
+++ b/Classes/Sitemap/Provider/SiteProvider.php
@@ -38,7 +38,7 @@ final class SiteProvider implements Provider
     public function get(
         Core\Site\Entity\Site $site,
         Core\Site\Entity\SiteLanguage $siteLanguage = null,
-    ): ?Sitemap\SiteAwareSitemap {
+    ): array {
         if ($siteLanguage !== null && $siteLanguage !== $site->getDefaultLanguage()) {
             $sitemapPath = $siteLanguage->toArray()['xml_sitemap_path'] ?? null;
         } else {
@@ -47,14 +47,16 @@ final class SiteProvider implements Provider
 
         // Early return if no sitemap path is configured
         if (!\is_string($sitemapPath) || trim($sitemapPath) === '') {
-            return null;
+            return [];
         }
 
-        return new Sitemap\SiteAwareSitemap(
+        $sitemap = new Sitemap\SiteAwareSitemap(
             Utility\HttpUtility::getSiteUrlWithPath($site, $sitemapPath, $siteLanguage),
             $site,
             $siteLanguage ?? $site->getDefaultLanguage(),
         );
+
+        return [$sitemap];
     }
 
     /**

--- a/Documentation/DeveloperCorner/Caching.rst
+++ b/Documentation/DeveloperCorner/Caching.rst
@@ -19,17 +19,17 @@ which defaults to a filesystem cache located at :file:`var/cache/code/warming/si
 
     ..  php:method:: get($site, $siteLanguage = null)
 
-        Get the located sitemap of a given site.
+        Get the located sitemaps of a given site.
 
         :param TYPO3\\CMS\\Core\\Site\\Entity\\Site $site: The sitemap's site object.
         :param TYPO3\\CMS\\Core\\Site\\Entity\\SiteLanguage $siteLanguage: An optional site language.
-        :returns: Located sitemap of a given site.
+        :returns: Located sitemaps of a given site.
 
-    ..  php:method:: set($sitemap)
+    ..  php:method:: set($sitemaps)
 
-        Add the located sitemap to the `warming` cache.
+        Add the located sitemaps to the `warming` cache.
 
-        :param EliasHaeussler\\Typo3Warming\\Sitemap\\SiteAwareSitemap $sitemap: The located sitemap to be cached.
+        :param array $sitemaps: The located sitemaps to be cached.
 
 ..  seealso::
 

--- a/Documentation/DeveloperCorner/SitemapProviders.rst
+++ b/Documentation/DeveloperCorner/SitemapProviders.rst
@@ -19,11 +19,11 @@ priority) to localize XML sitemaps according to certain criteria.
 
     ..  php:method:: get($site, $siteLanguage = null)
 
-        Locate the XML sitemap path of the given site.
+        Locate the XML sitemaps of the given site.
 
         :param TYPO3\\CMS\\Core\\Site\\Entity\\Site $site: The site whose XML sitemap path should be located.
         :param TYPO3\\CMS\\Core\\Site\\Entity\\SiteLanguage $siteLanguage: An optional site language to include while locating the XML sitemap path.
-        :returns: An instance of :php:class:`EliasHaeussler\\Typo3Warming\\Sitemap\\SiteAwareSitemap` or :php:`null`.
+        :returns: An array of instances of :php:class:`EliasHaeussler\\Typo3Warming\\Sitemap\\SiteAwareSitemap`.
 
     ..  php:staticmethod:: getPriority()
 
@@ -63,17 +63,14 @@ By default, the path to an XML sitemap is determined in three steps:
     Read more at `sitemaps.org <https://www.sitemaps.org/protocol.html#submit_robots>`__.
 
     ..  note::
-        Only the first occurrence will be respected. In the following
-        example, the resulting sitemap is
-        `https://www.example.com/our-sitemap.xml`.
 
-        ..  code-block:: none
-            :emphasize-lines: 3
+        ..  versionadded:: 1.0.0
 
-            User-agent: *
-            Disallow: /tmp/
-            Sitemap: https://www.example.com/our-sitemap.xml
-            Sitemap: https://www.example.com/our-other-sitemap.xml
+            `Feature #336 – Support multiple sitemaps to be located <https://github.com/eliashaeussler/typo3-warming/issues/336>`__
+
+        Since version 1.0.0 of EXT:warming, all sitemaps in `robots.txt`
+        are captured. Prior to this version, only the first occurrence was
+        respected.
 
 4.  Default path
 

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -75,6 +75,9 @@ Sitemap providers
     :php:interface:`EliasHaeussler\\Typo3Warming\\Sitemap\\Provider\\Provider`
     directly. The previously available trait method is now available within
     :php:meth:`EliasHaeussler\\Typo3Warming\\Utility\\HttpUtility::getSiteUrlWithPath`.
+-   :php:meth:`EliasHaeussler\\Typo3Warming\\Sitemap\\Provider\\Provider::get`
+    now returns an array of :php:class:`EliasHaeussler\\Typo3Warming\\Sitemap\\SiteAwareSitemap`
+    instances.
 -   A new sitemap provider
     :php:class:`EliasHaeussler\\Typo3Warming\\Sitemap\\Provider\\PageTypeProvider`
     was added. It is configured with highest priority. Read more at

--- a/Resources/Private/Partials/Modal/Sites/SiteGroup.html
+++ b/Resources/Private/Partials/Modal/Sites/SiteGroup.html
@@ -87,12 +87,12 @@
         }" />
     </label>
 
-    <f:for each="{siteGroup.items}" as="item">
+    <f:for each="{siteGroup.items}" as="item" iteration="iterator">
         <f:if condition="{item.missing}">
             <f:then>
                 <div class="tx-warming-sites-group-item tx-warming-sites-group-item-disabled">
                     <f:render partial="Modal/Sites/SiteGroupItem" section="checkbox" arguments="{
-                        identifier: 'tx-warming-checkbox-{siteGroup.site.identifier}-{item.language.languageId}',
+                        identifier: 'tx-warming-checkbox-{siteGroup.site.identifier}-{iterator.index}',
                         siteIdentifier: siteGroup.site.identifier,
                         languageIdentifier: item.language.languageId,
                         group: 1,
@@ -113,12 +113,12 @@
                 </div>
             </f:then>
             <f:else>
-                <label for="tx-warming-checkbox-{siteGroup.site.identifier}-{item.language.languageId}"
+                <label for="tx-warming-checkbox-{siteGroup.site.identifier}-{iterator.index}"
                        class="tx-warming-sites-group-item"
                        title="{item.language.title}"
                 >
                     <f:render partial="Modal/Sites/SiteGroupItem" section="checkbox" arguments="{
-                        identifier: 'tx-warming-checkbox-{siteGroup.site.identifier}-{item.language.languageId}',
+                        identifier: 'tx-warming-checkbox-{siteGroup.site.identifier}-{iterator.index}',
                         siteIdentifier: siteGroup.site.identifier,
                         languageIdentifier: item.language.languageId,
                         group: 1

--- a/Tests/Acceptance/Backend/ContextMenu/ItemProviders/CacheWarmupProviderCest.php
+++ b/Tests/Acceptance/Backend/ContextMenu/ItemProviders/CacheWarmupProviderCest.php
@@ -86,6 +86,18 @@ final class CacheWarmupProviderCest
         $extensionConfiguration->write('enablePageTree', true);
     }
 
+    public function cannotSeeContextMenuItemForSiteIfConfiguredSitemapIsInvalid(
+        Tests\Acceptance\Support\AcceptanceTester $I,
+        Tests\Acceptance\Support\Helper\PageTree $pageTree,
+    ): void {
+        $I->loginAs('admin');
+
+        $pageTree->openContextMenu(['Root 2']);
+
+        $I->see('Warmup cache for this page', Tests\Acceptance\Support\Enums\Selectors::ContextMenu->value);
+        $I->dontSee('Warmup all caches', Tests\Acceptance\Support\Enums\Selectors::ContextMenu->value);
+    }
+
     public function cannotSeeContextMenuItemForSiteIfNoSiteIsConfiguredForRootPage(
         Tests\Acceptance\Support\AcceptanceTester $I,
         Tests\Acceptance\Support\Helper\PageTree $pageTree,

--- a/Tests/Build/Configuration/sites/root-2/config.yaml
+++ b/Tests/Build/Configuration/sites/root-2/config.yaml
@@ -22,4 +22,4 @@ languages:
     languageId: 1
 rootPageId: 7
 websiteTitle: ''
-xml_sitemap_path: ''
+xml_sitemap_path: 'invalid-sitemap.xml'

--- a/Tests/Functional/Sitemap/Provider/PageTypeProviderTest.php
+++ b/Tests/Functional/Sitemap/Provider/PageTypeProviderTest.php
@@ -52,21 +52,21 @@ final class PageTypeProviderTest extends TestingFramework\Core\Functional\Functi
     }
 
     #[Framework\Attributes\Test]
-    public function getReturnsNullIfSeoExtensionIsNotLoaded(): void
+    public function getReturnsEmptyArrayIfSeoExtensionIsNotLoaded(): void
     {
         $site = new Core\Site\Entity\Site('foo', 1, []);
 
-        self::assertNull($this->subject->get($site));
+        self::assertSame([], $this->subject->get($site));
     }
 
     #[Framework\Attributes\Test]
-    public function getReturnsNullIfPageTypeIsNotConfigured(): void
+    public function getReturnsEmptyArrayIfPageTypeIsNotConfigured(): void
     {
         $this->packageManager->loadedExtensions = ['seo'];
 
         $site = new Core\Site\Entity\Site('foo', 1, []);
 
-        self::assertNull($this->subject->get($site));
+        self::assertSame([], $this->subject->get($site));
     }
 
     #[Framework\Attributes\Test]
@@ -86,11 +86,13 @@ final class PageTypeProviderTest extends TestingFramework\Core\Functional\Functi
             ],
         ]);
 
-        $expected = new Src\Sitemap\SiteAwareSitemap(
-            new Core\Http\Uri('https://www.example.com/baz.xml'),
-            $site,
-            $site->getDefaultLanguage(),
-        );
+        $expected = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri('https://www.example.com/baz.xml'),
+                $site,
+                $site->getDefaultLanguage(),
+            ),
+        ];
 
         self::assertEquals($expected, $this->subject->get($site));
     }
@@ -113,11 +115,13 @@ final class PageTypeProviderTest extends TestingFramework\Core\Functional\Functi
         ]);
         $siteLanguage = new Core\Site\Entity\SiteLanguage(1, 'de_DE.UTF-8', new Core\Http\Uri('https://www.example.com/de/'), []);
 
-        $expected = new Src\Sitemap\SiteAwareSitemap(
-            new Core\Http\Uri('https://www.example.com/de/baz.xml'),
-            $site,
-            $siteLanguage,
-        );
+        $expected = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri('https://www.example.com/de/baz.xml'),
+                $site,
+                $siteLanguage,
+            ),
+        ];
 
         self::assertEquals($expected, $this->subject->get($site, $siteLanguage));
     }

--- a/Tests/Functional/Sitemap/SitemapLocatorTest.php
+++ b/Tests/Functional/Sitemap/SitemapLocatorTest.php
@@ -101,15 +101,17 @@ final class SitemapLocatorTest extends TestingFramework\Core\Functional\Function
     public function locateBySiteReturnsCachedSitemap(?Core\Site\Entity\SiteLanguage $siteLanguage, string $expectedUrl): void
     {
         $site = self::getSite([]);
-        $sitemap = new Src\Sitemap\SiteAwareSitemap(
-            new Core\Http\Uri($expectedUrl),
-            $site,
-            $siteLanguage ?? $site->getDefaultLanguage(),
-        );
+        $sitemaps = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri($expectedUrl),
+                $site,
+                $siteLanguage ?? $site->getDefaultLanguage(),
+            ),
+        ];
 
-        $this->cache->set($sitemap);
+        $this->cache->set($sitemaps);
 
-        self::assertEquals($sitemap, $this->subject->locateBySite($site, $siteLanguage));
+        self::assertEquals($sitemaps, $this->subject->locateBySite($site, $siteLanguage));
     }
 
     #[Framework\Attributes\Test]
@@ -148,13 +150,15 @@ final class SitemapLocatorTest extends TestingFramework\Core\Functional\Function
     public function locateBySiteReturnsLocatedSitemap(?Core\Site\Entity\SiteLanguage $siteLanguage, string $expectedUrl): void
     {
         $site = self::getSite();
-        $sitemap = new Src\Sitemap\SiteAwareSitemap(
-            new Core\Http\Uri($expectedUrl),
-            $site,
-            $siteLanguage ?? $site->getDefaultLanguage(),
-        );
+        $sitemap = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri($expectedUrl),
+                $site,
+                $siteLanguage ?? $site->getDefaultLanguage(),
+            ),
+        ];
 
-        self::assertNull($this->cache->get($site, $siteLanguage));
+        self::assertSame([], $this->cache->get($site, $siteLanguage));
         self::assertEquals($sitemap, $this->subject->locateBySite($site, $siteLanguage));
         self::assertEquals($sitemap, $this->cache->get($site, $siteLanguage));
     }
@@ -211,39 +215,62 @@ final class SitemapLocatorTest extends TestingFramework\Core\Functional\Function
                 1 => self::getSiteLanguage()->toArray(),
             ],
         ]);
-        $sitemap = new Src\Sitemap\SiteAwareSitemap(
-            new Core\Http\Uri('https://www.example.com/'),
-            $site,
-            $site->getLanguageById(1),
-        );
+        $sitemaps = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri('https://www.example.com/'),
+                $site,
+                $site->getLanguageById(1),
+            ),
+        ];
 
-        $this->cache->set($sitemap);
+        $this->cache->set($sitemaps);
 
-        self::assertEquals([1 => $sitemap], $this->subject->locateAllBySite($site));
+        self::assertEquals([1 => $sitemaps], $this->subject->locateAllBySite($site));
     }
 
     #[Framework\Attributes\Test]
-    public function siteContainsSitemapReturnsFalseOnInaccessibleSitemap(): void
+    public function sitemapExistsReturnsFalseOnInaccessibleSitemap(): void
     {
         $this->requestFactory->exception = new Exception();
 
-        self::assertFalse($this->subject->siteContainsSitemap(self::getSite()));
+        $site = self::getSite();
+        $sitemap = new Src\Sitemap\SiteAwareSitemap(
+            new Core\Http\Uri('https://www.example.com/'),
+            $site,
+            $site->getDefaultLanguage(),
+        );
+
+        self::assertFalse($this->subject->sitemapExists($sitemap));
     }
 
     #[Framework\Attributes\Test]
-    public function siteContainsSitemapReturnsFalseOnFailedRequest(): void
+    public function sitemapExistsReturnsFalseOnFailedRequest(): void
     {
         $this->requestFactory->response = new Core\Http\Response(null, 404);
 
-        self::assertFalse($this->subject->siteContainsSitemap(self::getSite()));
+        $site = self::getSite();
+        $sitemap = new Src\Sitemap\SiteAwareSitemap(
+            new Core\Http\Uri('https://www.example.com/'),
+            $site,
+            $site->getDefaultLanguage(),
+        );
+
+        self::assertFalse($this->subject->sitemapExists($sitemap));
     }
 
     #[Framework\Attributes\Test]
-    public function siteContainsSitemapReturnsTrueOnSuccessfulRequest(): void
+    public function sitemapExistsReturnsTrueOnSuccessfulRequest(): void
     {
         $this->requestFactory->response = new Core\Http\Response();
 
-        self::assertTrue($this->subject->siteContainsSitemap(self::getSite()));
+        $site = self::getSite();
+        $sitemap = new Src\Sitemap\SiteAwareSitemap(
+            new Core\Http\Uri('https://www.example.com/'),
+            $site,
+            $site->getDefaultLanguage(),
+        );
+
+        self::assertTrue($this->subject->sitemapExists($sitemap));
     }
 
     /**

--- a/Tests/Unit/Sitemap/Provider/DefaultProviderTest.php
+++ b/Tests/Unit/Sitemap/Provider/DefaultProviderTest.php
@@ -49,11 +49,13 @@ final class DefaultProviderTest extends TestingFramework\Core\Unit\UnitTestCase
     public function getReturnsSitemapWithDefaultPath(): void
     {
         $site = new Core\Site\Entity\Site('foo', 1, ['base' => 'https://www.example.com/']);
-        $expected = new Src\Sitemap\SiteAwareSitemap(
-            new Core\Http\Uri('https://www.example.com/sitemap.xml'),
-            $site,
-            $site->getDefaultLanguage(),
-        );
+        $expected = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri('https://www.example.com/sitemap.xml'),
+                $site,
+                $site->getDefaultLanguage(),
+            ),
+        ];
 
         self::assertEquals($expected, $this->subject->get($site));
     }

--- a/Tests/Unit/Sitemap/Provider/RobotsTxtProviderTest.php
+++ b/Tests/Unit/Sitemap/Provider/RobotsTxtProviderTest.php
@@ -53,15 +53,15 @@ final class RobotsTxtProviderTest extends TestingFramework\Core\Unit\UnitTestCas
     }
 
     #[Framework\Attributes\Test]
-    public function getReturnsNullIfNoRobotsTxtExists(): void
+    public function getReturnsEmptyArrayIfNoRobotsTxtExists(): void
     {
         $this->requestFactory->exception = new Exception();
 
-        self::assertNull($this->subject->get($this->site));
+        self::assertSame([], $this->subject->get($this->site));
     }
 
     #[Framework\Attributes\Test]
-    public function getReturnsNullIfNoRobotsTxtDoesNotContainSitemapConfiguration(): void
+    public function getReturnsEmptyArrayIfNoRobotsTxtDoesNotContainSitemapConfiguration(): void
     {
         $response = new Core\Http\Response();
         $body = $response->getBody();
@@ -70,7 +70,7 @@ final class RobotsTxtProviderTest extends TestingFramework\Core\Unit\UnitTestCas
 
         $this->requestFactory->response = $response;
 
-        self::assertNull($this->subject->get($this->site));
+        self::assertSame([], $this->subject->get($this->site));
     }
 
     #[Framework\Attributes\Test]
@@ -78,16 +78,28 @@ final class RobotsTxtProviderTest extends TestingFramework\Core\Unit\UnitTestCas
     {
         $response = new Core\Http\Response();
         $body = $response->getBody();
-        $body->write('Sitemap: https://www.example.com/baz.xml');
+        $body->write(
+            <<<TXT
+Sitemap: https://www.example.com/baz.xml
+Sitemap: https://www.example.com/bar.xml
+TXT
+        );
         $body->rewind();
 
         $this->requestFactory->response = $response;
 
-        $expected = new Src\Sitemap\SiteAwareSitemap(
-            new Core\Http\Uri('https://www.example.com/baz.xml'),
-            $this->site,
-            $this->site->getDefaultLanguage(),
-        );
+        $expected = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri('https://www.example.com/baz.xml'),
+                $this->site,
+                $this->site->getDefaultLanguage(),
+            ),
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri('https://www.example.com/bar.xml'),
+                $this->site,
+                $this->site->getDefaultLanguage(),
+            ),
+        ];
 
         self::assertEquals($expected, $this->subject->get($this->site));
     }

--- a/Tests/Unit/Sitemap/Provider/SiteProviderTest.php
+++ b/Tests/Unit/Sitemap/Provider/SiteProviderTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Warming\Tests\Unit\Sitemap\Provider;
 
 use EliasHaeussler\Typo3Warming as Src;
 use Generator;
-use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework;
 use TYPO3\CMS\Core;
 use TYPO3\TestingFramework;
@@ -48,11 +47,11 @@ final class SiteProviderTest extends TestingFramework\Core\Unit\UnitTestCase
     }
 
     #[Framework\Attributes\Test]
-    public function getReturnsNullIfSitemapPathIsNotConfiguredInSite(): void
+    public function getReturnsEmptyArrayIfSitemapPathIsNotConfiguredInSite(): void
     {
         $site = new Core\Site\Entity\Site('foo', 1, []);
 
-        self::assertNull($this->subject->get($site));
+        self::assertSame([], $this->subject->get($site));
     }
 
     #[Framework\Attributes\Test]
@@ -63,11 +62,15 @@ final class SiteProviderTest extends TestingFramework\Core\Unit\UnitTestCase
             'base' => 'https://www.example.com/',
             'xml_sitemap_path' => $path,
         ]);
+        $sitemaps = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri($expected),
+                $site,
+                $site->getDefaultLanguage(),
+            ),
+        ];
 
-        self::assertEquals(
-            new Src\Sitemap\SiteAwareSitemap(new Core\Http\Uri($expected), $site, $site->getDefaultLanguage()),
-            $this->subject->get($site),
-        );
+        self::assertEquals($sitemaps, $this->subject->get($site));
     }
 
     #[Framework\Attributes\Test]
@@ -80,16 +83,20 @@ final class SiteProviderTest extends TestingFramework\Core\Unit\UnitTestCase
         $siteLanguage = new Core\Site\Entity\SiteLanguage(
             1,
             'de_DE.UTF-8',
-            new Uri('https://www.example.com/de'),
+            new Core\Http\Uri('https://www.example.com/de'),
             [
                 'xml_sitemap_path' => $path,
             ],
         );
+        $sitemaps = [
+            new Src\Sitemap\SiteAwareSitemap(
+                new Core\Http\Uri($expected),
+                $site,
+                $siteLanguage,
+            ),
+        ];
 
-        self::assertEquals(
-            new Src\Sitemap\SiteAwareSitemap(new Uri($expected), $site, $siteLanguage),
-            $this->subject->get($site, $siteLanguage),
-        );
+        self::assertEquals($sitemaps, $this->subject->get($site, $siteLanguage));
     }
 
     /**


### PR DESCRIPTION
This PR changes the way how sitemaps are located in order to support multiple sitemaps being returned by sitemap providers. This is especially useful when using a `robots.txt` file with multiple `Sitemap` declarations. Prior to this change, only the first sitemap was respected. With this PR, all declared sitemaps are now returned.

⚠️ This is a breaking change as it changes the method signature in `EliasHaeussler\Typo3Warming\Sitemap\Provider\Provider::get()`.

Related: #199