### PR TITLE
[BUGFIX] Don't exclude `Configuration` directory in TER package

### DIFF
--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -29,7 +29,6 @@ return [
         '.github',
         'bin',
         'build',
-        'config',
         'public',
         'resources\\/private\\/frontend',
         'resources\\/private\\/libs\\/build',


### PR DESCRIPTION
When packaging for TER, the `Configuration` directory was excluded by accident. This is now fixed and the directory should be included again.