### PR TITLE
[BUGFIX] Support custom identifiers for PageType enhancer

### DIFF
--- a/Tests/Functional/Sitemap/Provider/PageTypeProviderTest.php
+++ b/Tests/Functional/Sitemap/Provider/PageTypeProviderTest.php
@@ -60,11 +60,32 @@ final class PageTypeProviderTest extends TestingFramework\Core\Functional\Functi
     }
 
     #[Framework\Attributes\Test]
-    public function getReturnsEmptyArrayIfPageTypeIsNotConfigured(): void
+    public function getReturnsEmptyArrayIfNoRouteEnhancersAreConfigured(): void
     {
         $this->packageManager->loadedExtensions = ['seo'];
 
         $site = new Core\Site\Entity\Site('foo', 1, []);
+
+        self::assertSame([], $this->subject->get($site));
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsEmptyArrayIfPageTypeIsNotConfigured(): void
+    {
+        $this->packageManager->loadedExtensions = ['seo'];
+
+        $site = new Core\Site\Entity\Site('foo', 1, [
+            'base' => 'https://www.example.com/',
+            'routeEnhancers' => [
+                'Foo' => [
+                    'type' => 'Simple',
+                    'routePath' => '/foo/{foo_id}',
+                    '_arguments' => [
+                        'foo_id' => 'foo/id',
+                    ],
+                ],
+            ],
+        ]);
 
         self::assertSame([], $this->subject->get($site));
     }


### PR DESCRIPTION
The previous implementation of the `PageTypeProvider` only respected the identifier `PageTypeSuffix` for configuration of the `PageType` enhancer. However, any identifier is supported in TYPO3 core for route enhancers. All other identifiers were therefore ignored by the `PageTypeProvider`.

This is now fixed and all enhancer configurations are respected. With this PR, the following enhancer configurations are accepted:

```yaml
# Example from TYPO3 documentation

routeEnhancers:
  PageTypeSuffix:
    type: PageType
    map:
      'sitemap.xml': 1533906435
```

```yaml
# Custom enhancer identifier

routeEnhancers:
  foo:
    type: PageType
    map:
      'sitemap.xml': 1533906435
```