### PR TITLE
[TASK] Use default Renovate preset next to TYPO3 extension preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
+		"local>eliashaeussler/renovate-config",
 		"local>eliashaeussler/renovate-config:typo3-extension"
 	]
 }


### PR DESCRIPTION
The TYPO3 extension preset no longer extends from the default preset, therefore both presets must be included explicitly.