### PR TITLE
[BUGFIX] Extract warmup request id from query parameters

### DIFF
--- a/Classes/ValueObject/Request/WarmupRequest.php
+++ b/Classes/ValueObject/Request/WarmupRequest.php
@@ -32,20 +32,16 @@ namespace EliasHaeussler\Typo3Warming\ValueObject\Request;
 final class WarmupRequest
 {
     /**
-     * @var non-empty-string
-     */
-    private readonly string $id;
-
-    /**
+     * @param non-empty-string $requestId
      * @param list<SiteWarmupRequest> $sites
      * @param list<PageWarmupRequest> $pages
      */
     public function __construct(
+        private readonly string $requestId,
         private readonly array $sites = [],
         private readonly array $pages = [],
         private readonly RequestConfiguration $configuration = new RequestConfiguration(),
     ) {
-        $this->id = uniqid('_', true);
     }
 
     /**
@@ -53,7 +49,7 @@ final class WarmupRequest
      */
     public function getId(): string
     {
-        return $this->id;
+        return $this->requestId;
     }
 
     /**

--- a/Tests/Functional/Controller/CacheWarmupLegacyControllerTest.php
+++ b/Tests/Functional/Controller/CacheWarmupLegacyControllerTest.php
@@ -109,6 +109,7 @@ final class CacheWarmupLegacyControllerTest extends TestingFramework\Core\Functi
 
         $request = new Core\Http\ServerRequest();
         $request = $request->withQueryParams([
+            'requestId' => 'foo',
             'sites' => [
                 [
                     'site' => $this->site->getIdentifier(),

--- a/Tests/Functional/Http/Message/Event/WarmupFinishedEventTest.php
+++ b/Tests/Functional/Http/Message/Event/WarmupFinishedEventTest.php
@@ -73,6 +73,7 @@ final class WarmupFinishedEventTest extends TestingFramework\Core\Functional\Fun
         );
         $this->subject = new Src\Http\Message\Event\WarmupFinishedEvent(
             new Src\ValueObject\Request\WarmupRequest(
+                'foo',
                 [
                     new Src\ValueObject\Request\SiteWarmupRequest($site, [0, 1]),
                 ],
@@ -158,7 +159,7 @@ final class WarmupFinishedEventTest extends TestingFramework\Core\Functional\Fun
         $message = Src\Configuration\Localization::translate('notification.message.empty');
 
         $subject = new Src\Http\Message\Event\WarmupFinishedEvent(
-            new Src\ValueObject\Request\WarmupRequest(),
+            new Src\ValueObject\Request\WarmupRequest('foo'),
             $this->cacheWarmupResult,
         );
 
@@ -172,6 +173,7 @@ final class WarmupFinishedEventTest extends TestingFramework\Core\Functional\Fun
     {
         $subject = new Src\Http\Message\Event\WarmupFinishedEvent(
             new Src\ValueObject\Request\WarmupRequest(
+                'foo',
                 pages: [
                     new Src\ValueObject\Request\PageWarmupRequest(99),
                 ],

--- a/Tests/Unit/ValueObject/Request/WarmupRequestTest.php
+++ b/Tests/Unit/ValueObject/Request/WarmupRequestTest.php
@@ -52,13 +52,18 @@ final class WarmupRequestTest extends TestingFramework\Core\Unit\UnitTestCase
         );
         $this->page = new Src\ValueObject\Request\PageWarmupRequest(7);
         $this->configuration = new Src\ValueObject\Request\RequestConfiguration(50, 'foo');
-        $this->subject = new Src\ValueObject\Request\WarmupRequest([$this->site], [$this->page], $this->configuration);
+        $this->subject = new Src\ValueObject\Request\WarmupRequest(
+            'foo',
+            [$this->site],
+            [$this->page],
+            $this->configuration,
+        );
     }
 
     #[Framework\Attributes\Test]
     public function getIdReturnsId(): void
     {
-        self::assertNotEmpty($this->subject->getId());
+        self::assertSame('foo', $this->subject->getId());
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
This PR fixes the `WarmupRequest` value object to be able to actually map the request id from request query parameters to the object during hydration.