### PR TITLE
[TASK] Drop outdated configuration from `ext_emconf.php`

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,6 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'be',
     'version' => '0.5.2',
     'state' => 'beta',
-    'clearCacheOnLoad' => true,
     'author' => 'Elias Häußler',
     'author_email' => 'elias@haeussler.dev',
     'constraints' => [


### PR DESCRIPTION
This PR removes an outdated configuration option from `ext_emconf.php` as suggested by Rector.