### PR TITLE
[TASK] Improve sitemaps cache handling

### DIFF
--- a/Documentation/DeveloperCorner/Caching.rst
+++ b/Documentation/DeveloperCorner/Caching.rst
@@ -9,7 +9,7 @@ Caching
 Once a sitemap is located by a :ref:`sitemap provider <sitemap-providers>`,
 the path to the XML sitemap is cached. This speeds up following
 warmup requests. Caching happens with a custom `warming` cache
-which defaults to a filesystem cache located at :file:`var/cache/code/warming/sitemaps.php`.
+which defaults to a filesystem cache located at :file:`var/cache/code/warming`.
 
 ..  php:namespace:: EliasHaeussler\Typo3Warming\Cache
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: Tests/Acceptance/Support/Helper/PageTree.php
 
 		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertFalse\\(\\) with string will always evaluate to false\\.$#"
-			count: 1
-			path: Tests/Functional/Cache/SitemapsCacheTest.php
-
-		-
 			message: "#^Parameter \\#1 \\$level \\('alert'\\|'critical'\\|'debug'\\|'emergency'\\|'error'\\|'info'\\|'notice'\\|'warning'\\) of method EliasHaeussler\\\\Typo3Warming\\\\Tests\\\\Functional\\\\Fixtures\\\\Classes\\\\DummyLogger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\AbstractLogger\\:\\:log\\(\\)$#"
 			count: 1
 			path: Tests/Functional/Fixtures/Classes/DummyLogger.php


### PR DESCRIPTION
This PR improves handling of sitemaps cache by using a separate cache entry for each site. This way, the complete Caching API of TYPO3 can be used to modify cache entries, instead of re-implementing several filesystem-based parts (reading, writing, manipulating) on our own.