### PR TITLE
[TASK] Use private properties everywhere in tests

### DIFF
--- a/Tests/Functional/Cache/SitemapsCacheTest.php
+++ b/Tests/Functional/Cache/SitemapsCacheTest.php
@@ -43,8 +43,8 @@ final class SitemapsCacheTest extends TestingFramework\Core\Functional\Functiona
 
     protected bool $initializeDatabase = false;
 
-    protected Core\Cache\Frontend\PhpFrontend $cache;
-    protected Src\Cache\SitemapsCache $subject;
+    private Core\Cache\Frontend\PhpFrontend $cache;
+    private Src\Cache\SitemapsCache $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/ClientMockTrait.php
+++ b/Tests/Functional/ClientMockTrait.php
@@ -35,7 +35,7 @@ use TYPO3\CMS\Core;
  */
 trait ClientMockTrait
 {
-    protected Tests\Functional\Fixtures\Classes\DummyGuzzleClientFactory $guzzleClientFactory;
+    private Tests\Functional\Fixtures\Classes\DummyGuzzleClientFactory $guzzleClientFactory;
 
     private function mockSitemapResponse(string ...$languages): void
     {

--- a/Tests/Functional/Command/ShowUserAgentCommandTest.php
+++ b/Tests/Functional/Command/ShowUserAgentCommandTest.php
@@ -43,8 +43,8 @@ final class ShowUserAgentCommandTest extends TestingFramework\Core\Functional\Fu
 
     protected bool $initializeDatabase = false;
 
-    protected Src\Configuration\Configuration $configuration;
-    protected Console\Tester\CommandTester $commandTester;
+    private Src\Configuration\Configuration $configuration;
+    private Console\Tester\CommandTester $commandTester;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Command/WarmupCommandTest.php
+++ b/Tests/Functional/Command/WarmupCommandTest.php
@@ -55,10 +55,10 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
         ],
     ];
 
-    protected Core\Site\Entity\Site $site;
-    protected Src\Configuration\Configuration $configuration;
-    protected Core\Configuration\ExtensionConfiguration $extensionConfiguration;
-    protected Console\Tester\CommandTester $commandTester;
+    private Core\Site\Entity\Site $site;
+    private Src\Configuration\Configuration $configuration;
+    private Core\Configuration\ExtensionConfiguration $extensionConfiguration;
+    private Console\Tester\CommandTester $commandTester;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Configuration/ConfigurationTest.php
+++ b/Tests/Functional/Configuration/ConfigurationTest.php
@@ -52,8 +52,8 @@ final class ConfigurationTest extends TestingFramework\Core\Functional\Functiona
 
     protected bool $initializeDatabase = false;
 
-    protected Core\Configuration\ExtensionConfiguration $extensionConfiguration;
-    protected Src\Configuration\Configuration $subject;
+    private Core\Configuration\ExtensionConfiguration $extensionConfiguration;
+    private Src\Configuration\Configuration $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Controller/CacheWarmupControllerTest.php
+++ b/Tests/Functional/Controller/CacheWarmupControllerTest.php
@@ -41,7 +41,7 @@ final class CacheWarmupControllerTest extends TestingFramework\Core\Functional\F
         'warming',
     ];
 
-    protected Src\Controller\CacheWarmupController $subject;
+    private Src\Controller\CacheWarmupController $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Controller/CacheWarmupLegacyControllerTest.php
+++ b/Tests/Functional/Controller/CacheWarmupLegacyControllerTest.php
@@ -56,9 +56,9 @@ final class CacheWarmupLegacyControllerTest extends TestingFramework\Core\Functi
         ],
     ];
 
-    protected Core\Site\Entity\Site $site;
-    protected Tests\Functional\Fixtures\Classes\DummyGuzzleClientFactory $guzzleClientFactory;
-    protected Src\Controller\CacheWarmupLegacyController $subject;
+    private Core\Site\Entity\Site $site;
+    private Tests\Functional\Fixtures\Classes\DummyGuzzleClientFactory $guzzleClientFactory;
+    private Src\Controller\CacheWarmupLegacyController $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+++ b/Tests/Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
@@ -49,7 +49,7 @@ final class ConcurrentUserAgentCrawlerTest extends TestingFramework\Core\Functio
 
     protected bool $initializeDatabase = false;
 
-    protected Src\Crawler\ConcurrentUserAgentCrawler $subject;
+    private Src\Crawler\ConcurrentUserAgentCrawler $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+++ b/Tests/Functional/Crawler/OutputtingUserAgentCrawlerTest.php
@@ -50,8 +50,8 @@ final class OutputtingUserAgentCrawlerTest extends TestingFramework\Core\Functio
 
     protected bool $initializeDatabase = false;
 
-    protected Console\Output\BufferedOutput $output;
-    protected Src\Crawler\OutputtingUserAgentCrawler $subject;
+    private Console\Output\BufferedOutput $output;
+    private Src\Crawler\OutputtingUserAgentCrawler $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Http/Message/Event/WarmupFinishedEventTest.php
+++ b/Tests/Functional/Http/Message/Event/WarmupFinishedEventTest.php
@@ -45,8 +45,8 @@ final class WarmupFinishedEventTest extends TestingFramework\Core\Functional\Fun
         'warming',
     ];
 
-    protected Src\Result\CacheWarmupResult $cacheWarmupResult;
-    protected Src\Http\Message\Event\WarmupFinishedEvent $subject;
+    private Src\Result\CacheWarmupResult $cacheWarmupResult;
+    private Src\Http\Message\Event\WarmupFinishedEvent $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Http/Message/ResponseFactoryTest.php
+++ b/Tests/Functional/Http/Message/ResponseFactoryTest.php
@@ -43,7 +43,7 @@ final class ResponseFactoryTest extends TestingFramework\Core\Functional\Functio
 
     protected bool $initializeDatabase = false;
 
-    protected Src\Http\Message\ResponseFactory $subject;
+    private Src\Http\Message\ResponseFactory $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Log/Writer/DatabaseWriterTest.php
+++ b/Tests/Functional/Log/Writer/DatabaseWriterTest.php
@@ -47,11 +47,11 @@ final class DatabaseWriterTest extends TestingFramework\Core\Functional\Function
         'warming',
     ];
 
-    protected Src\Log\Writer\DatabaseWriter $subject;
-    protected Core\Database\Connection $connection;
-    protected Core\Site\Entity\Site $site;
-    protected CacheWarmup\Sitemap\Url $uri;
-    protected Core\Log\LogRecord $logRecord;
+    private Src\Log\Writer\DatabaseWriter $subject;
+    private Core\Database\Connection $connection;
+    private Core\Site\Entity\Site $site;
+    private CacheWarmup\Sitemap\Url $uri;
+    private Core\Log\LogRecord $logRecord;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Service/CacheWarmupServiceTest.php
+++ b/Tests/Functional/Service/CacheWarmupServiceTest.php
@@ -55,10 +55,10 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
         ],
     ];
 
-    protected Core\Site\Entity\Site $site;
-    protected Tests\Functional\Fixtures\Classes\DummyEventDispatcher $eventDispatcher;
-    protected Tests\Functional\Fixtures\Classes\DummyGuzzleClientFactory $guzzleClientFactory;
-    protected Src\Service\CacheWarmupService $subject;
+    private Core\Site\Entity\Site $site;
+    private Tests\Functional\Fixtures\Classes\DummyEventDispatcher $eventDispatcher;
+    private Tests\Functional\Fixtures\Classes\DummyGuzzleClientFactory $guzzleClientFactory;
+    private Src\Service\CacheWarmupService $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Sitemap/Provider/PageTypeProviderTest.php
+++ b/Tests/Functional/Sitemap/Provider/PageTypeProviderTest.php
@@ -38,8 +38,8 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Sitemap\Provider\PageTypeProvider::class)]
 final class PageTypeProviderTest extends TestingFramework\Core\Functional\FunctionalTestCase
 {
-    protected Src\Sitemap\Provider\PageTypeProvider $subject;
-    protected Tests\Functional\Fixtures\Classes\DummyPackageManager $packageManager;
+    private Src\Sitemap\Provider\PageTypeProvider $subject;
+    private Tests\Functional\Fixtures\Classes\DummyPackageManager $packageManager;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Sitemap/SitemapLocatorTest.php
+++ b/Tests/Functional/Sitemap/SitemapLocatorTest.php
@@ -45,9 +45,9 @@ final class SitemapLocatorTest extends TestingFramework\Core\Functional\Function
         'warming',
     ];
 
-    protected Src\Cache\SitemapsCache $cache;
-    protected Tests\Unit\Fixtures\DummyRequestFactory $requestFactory;
-    protected Src\Sitemap\SitemapLocator $subject;
+    private Src\Cache\SitemapsCache $cache;
+    private Tests\Unit\Fixtures\DummyRequestFactory $requestFactory;
+    private Src\Sitemap\SitemapLocator $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Utility/AccessUtilityTest.php
+++ b/Tests/Functional/Utility/AccessUtilityTest.php
@@ -40,7 +40,7 @@ final class AccessUtilityTest extends TestingFramework\Core\Functional\Functiona
 {
     use Tests\Functional\SiteTrait;
 
-    protected Core\Site\Entity\Site $site;
+    private Core\Site\Entity\Site $site;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/Utility/HttpUtilityTest.php
+++ b/Tests/Functional/Utility/HttpUtilityTest.php
@@ -40,7 +40,7 @@ final class HttpUtilityTest extends TestingFramework\Core\Functional\FunctionalT
 {
     use Tests\Functional\SiteTrait;
 
-    protected Core\Site\Entity\Site $site;
+    private Core\Site\Entity\Site $site;
 
     protected function setUp(): void
     {

--- a/Tests/Functional/View/TemplateRendererTest.php
+++ b/Tests/Functional/View/TemplateRendererTest.php
@@ -40,7 +40,7 @@ final class TemplateRendererTest extends TestingFramework\Core\Functional\Functi
         'warming',
     ];
 
-    protected Src\View\TemplateRenderer $subject;
+    private Src\View\TemplateRenderer $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Crawler/Strategy/CrawlingStrategyFactoryTest.php
+++ b/Tests/Unit/Crawler/Strategy/CrawlingStrategyFactoryTest.php
@@ -38,7 +38,7 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Crawler\Strategy\CrawlingStrategyFactory::class)]
 final class CrawlingStrategyFactoryTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Src\Crawler\Strategy\CrawlingStrategyFactory $subject;
+    private Src\Crawler\Strategy\CrawlingStrategyFactory $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Domain/Type/StateTypeTest.php
+++ b/Tests/Unit/Domain/Type/StateTypeTest.php
@@ -36,7 +36,7 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Domain\Type\StateType::class)]
 final class StateTypeTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Src\Domain\Type\StateType $subject;
+    private Src\Domain\Type\StateType $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Http/Client/ClientFactoryTest.php
+++ b/Tests/Unit/Http/Client/ClientFactoryTest.php
@@ -40,8 +40,8 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Http\Client\ClientFactory::class)]
 final class ClientFactoryTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Core\Http\Client\GuzzleClientFactory $guzzleClientFactory;
-    protected Src\Http\Client\ClientFactory $subject;
+    private Core\Http\Client\GuzzleClientFactory $guzzleClientFactory;
+    private Src\Http\Client\ClientFactory $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Http/Message/Event/WarmupProgressEventTest.php
+++ b/Tests/Unit/Http/Message/Event/WarmupProgressEventTest.php
@@ -36,7 +36,7 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Http\Message\Event\WarmupProgressEvent::class)]
 final class WarmupProgressEventTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Src\Http\Message\Event\WarmupProgressEvent $subject;
+    private Src\Http\Message\Event\WarmupProgressEvent $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Http/Message/Handler/StreamResponseHandlerTest.php
+++ b/Tests/Unit/Http/Message/Handler/StreamResponseHandlerTest.php
@@ -39,8 +39,8 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Http\Message\Handler\StreamResponseHandler::class)]
 final class StreamResponseHandlerTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Tests\Unit\Fixtures\DummyEventStream $eventStream;
-    protected Src\Http\Message\Handler\StreamResponseHandler $subject;
+    private Tests\Unit\Fixtures\DummyEventStream $eventStream;
+    private Src\Http\Message\Handler\StreamResponseHandler $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Http/Message/ResponseFactoryTest.php
+++ b/Tests/Unit/Http/Message/ResponseFactoryTest.php
@@ -37,7 +37,7 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Http\Message\ResponseFactory::class)]
 final class ResponseFactoryTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Src\Http\Message\ResponseFactory $subject;
+    private Src\Http\Message\ResponseFactory $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Mapper/MapperFactoryTest.php
+++ b/Tests/Unit/Mapper/MapperFactoryTest.php
@@ -38,8 +38,8 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Mapper\MapperFactory::class)]
 final class MapperFactoryTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Tests\Unit\Fixtures\DummySiteFinder $siteFinder;
-    protected Src\Mapper\MapperFactory $subject;
+    private Tests\Unit\Fixtures\DummySiteFinder $siteFinder;
+    private Src\Mapper\MapperFactory $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Result/CacheWarmupResultTest.php
+++ b/Tests/Unit/Result/CacheWarmupResultTest.php
@@ -41,9 +41,9 @@ final class CacheWarmupResultTest extends TestingFramework\Core\Unit\UnitTestCas
 {
     use Tests\Unit\SiteTrait;
 
-    protected CacheWarmup\Result\CacheWarmupResult $originalResult;
-    protected Core\Site\Entity\Site $site;
-    protected Src\Result\CacheWarmupResult $subject;
+    private CacheWarmup\Result\CacheWarmupResult $originalResult;
+    private Core\Site\Entity\Site $site;
+    private Src\Result\CacheWarmupResult $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Sitemap/Provider/DefaultProviderTest.php
+++ b/Tests/Unit/Sitemap/Provider/DefaultProviderTest.php
@@ -37,7 +37,7 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Sitemap\Provider\DefaultProvider::class)]
 final class DefaultProviderTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Src\Sitemap\Provider\DefaultProvider $subject;
+    private Src\Sitemap\Provider\DefaultProvider $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Sitemap/Provider/RobotsTxtProviderTest.php
+++ b/Tests/Unit/Sitemap/Provider/RobotsTxtProviderTest.php
@@ -39,9 +39,9 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Sitemap\Provider\RobotsTxtProvider::class)]
 final class RobotsTxtProviderTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Tests\Unit\Fixtures\DummyRequestFactory $requestFactory;
-    protected Core\Site\Entity\Site $site;
-    protected Src\Sitemap\Provider\RobotsTxtProvider $subject;
+    private Tests\Unit\Fixtures\DummyRequestFactory $requestFactory;
+    private Core\Site\Entity\Site $site;
+    private Src\Sitemap\Provider\RobotsTxtProvider $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/Sitemap/Provider/SiteProviderTest.php
+++ b/Tests/Unit/Sitemap/Provider/SiteProviderTest.php
@@ -38,7 +38,7 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Sitemap\Provider\SiteProvider::class)]
 final class SiteProviderTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Src\Sitemap\Provider\SiteProvider $subject;
+    private Src\Sitemap\Provider\SiteProvider $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/ValueObject/Request/SiteWarmupRequestTest.php
+++ b/Tests/Unit/ValueObject/Request/SiteWarmupRequestTest.php
@@ -39,8 +39,8 @@ final class SiteWarmupRequestTest extends TestingFramework\Core\Unit\UnitTestCas
 {
     use Src\Tests\Unit\SiteTrait;
 
-    protected Core\Site\Entity\Site $site;
-    protected Src\ValueObject\Request\SiteWarmupRequest $subject;
+    private Core\Site\Entity\Site $site;
+    private Src\ValueObject\Request\SiteWarmupRequest $subject;
 
     protected function setUp(): void
     {

--- a/Tests/Unit/ValueObject/Request/WarmupRequestTest.php
+++ b/Tests/Unit/ValueObject/Request/WarmupRequestTest.php
@@ -37,10 +37,10 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\ValueObject\Request\WarmupRequest::class)]
 final class WarmupRequestTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    protected Src\ValueObject\Request\SiteWarmupRequest $site;
-    protected Src\ValueObject\Request\PageWarmupRequest $page;
-    protected Src\ValueObject\Request\RequestConfiguration $configuration;
-    protected Src\ValueObject\Request\WarmupRequest $subject;
+    private Src\ValueObject\Request\SiteWarmupRequest $site;
+    private Src\ValueObject\Request\PageWarmupRequest $page;
+    private Src\ValueObject\Request\RequestConfiguration $configuration;
+    private Src\ValueObject\Request\WarmupRequest $subject;
 
     protected function setUp(): void
     {

--- a/rector.php
+++ b/rector.php
@@ -27,7 +27,6 @@ use Rector\Core\ValueObject\PhpVersion;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
-use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Rector\Symfony\Rector\Class_\CommandDescriptionToPropertyRector;
 use Rector\Symfony\Rector\Class_\CommandPropertyToAttributeRector;
 
@@ -74,11 +73,6 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/Classes/Domain/Repository/*',
             // We keep the main sitemap class open for extensions
             __DIR__ . '/Classes/Sitemap/SiteAwareSitemap.php',
-        ])
-        ->skip(PrivatizeFinalClassPropertyRector::class, [
-            // Test properties must not be private, otherwise TF cannot perform GC tasks
-            __DIR__ . '/Tests/Functional/*',
-            __DIR__ . '/Tests/Unit/*',
         ])
         ->apply()
     ;


### PR DESCRIPTION
Due to TYPO3/testing-framework@f55c7154e48c48d956a656fd1e8ebd60d7a515cf no more garbage collection tasks are performed in `tearDown()` method of tests. Therefore, we can safely convert all test properties to private properties.