### PR TITLE
[TASK] Check Frontend asset integrity in CGL workflow

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -58,6 +58,13 @@ jobs:
       - name: Install Frontend dependencies
         run: yarn --cwd Resources/Private/Frontend --frozen-lockfile
 
+      # Check asset integrity
+      - name: Check Frontend asset integrity
+        run: |
+          yarn --cwd Resources/Private/Frontend build
+          git add Resources/Public
+          git diff --exit-code --staged Resources/Public
+
       # Frontend linting
       - name: Lint SCSS
         run: yarn --cwd Resources/Private/Frontend lint:scss


### PR DESCRIPTION
A new step is added to the CGL workflow that validates Frontend asset integrity. It re-builds Frontend assets and checks if any changes were made.