### PR TITLE
[BUGFIX] Configure server-type in `ddev init-typo3` command

### DIFF
--- a/.ddev/commands/web/init-typo3
+++ b/.ddev/commands/web/init-typo3
@@ -39,6 +39,7 @@ export TYPO3_DB_DBNAME="$dbName"
 export TYPO3_SETUP_ADMIN_EMAIL=admin@example.com
 export TYPO3_SETUP_ADMIN_USERNAME=admin
 export TYPO3_SETUP_ADMIN_PASSWORD=Passw0rd!
+export TYPO3_SERVER_TYPE=other
 export TYPO3_PROJECT_NAME="EXT:warming"
 
 # Set up environment


### PR DESCRIPTION
TYPO3 12.4.6 requires a server-type to be configured when using the `typo3 setup` command non-interactively. This PR adds the appropriate configuration as environment variable.