### PR TITLE
[BUGFIX] Inject TYPO3's client into sub-command

### DIFF
--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -29,6 +29,7 @@ use EliasHaeussler\Typo3Warming\Exception\UnsupportedConfigurationException;
 use EliasHaeussler\Typo3Warming\Exception\UnsupportedSiteException;
 use EliasHaeussler\Typo3Warming\Service\CacheWarmupService;
 use EliasHaeussler\Typo3Warming\Sitemap\SitemapLocator;
+use Psr\Http\Client\ClientInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -37,6 +38,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Http\Client\GuzzleClientFactory;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
@@ -188,6 +190,12 @@ final class WarmupCommand extends Command
         $subCommand->setApplication($this->getApplication() ?? new Application());
         $subCommandInput = $this->initializeSubCommandInput($subCommand, $input);
         $subCommandInput->setInteractive(false);
+
+        // Inject client
+        $client = GuzzleClientFactory::getClient();
+        if ($client instanceof ClientInterface) {
+            $subCommand->setClient($client);
+        }
 
         $output->writeln('Running <info>cache warmup</info> by <info>Elias Häußler</info> and contributors.');
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"eliashaeussler/cache-warmup": ">= 0.5.0. < 1.0.0",
 		"guzzlehttp/guzzle": "^6.3 || ^7.0",
 		"guzzlehttp/psr7": "^1.4 || ^2.0",
+		"psr/http-client": "^1.0",
 		"psr/http-message": "^1.0",
 		"psr/log": "^1.0",
 		"symfony/console": "^4.4 || ^5.4 || ^6.0",


### PR DESCRIPTION
This PR now passes TYPO3's client to the underlying sub-command when running the `warming:cachewarmup` command. This assures that globally configured HTTP options are used.