### PR TITLE
[BUGFIX] Checkout explicit ref when rebuilding assets

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       # Install Frontend dependencies
       - name: Install Frontend dependencies


### PR DESCRIPTION
This PR changes the way how the `actions/checkout` is used to rebuild frontend assets: The current head ref is now explicitly checked out to properly commit changes.