### PR TITLE
[FEATURE] Allow configuration of XML parser client options

### DIFF
--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -200,8 +200,12 @@ final class WarmupCommand extends Console\Command\Command
      */
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
+        // Initialize client
+        $clientOptions = $this->configuration->getParserClientOptions();
+        $client = $this->clientFactory->get($clientOptions);
+
         // Initialize sub command
-        $subCommand = new CacheWarmup\Command\CacheWarmupCommand($this->clientFactory->get());
+        $subCommand = new CacheWarmup\Command\CacheWarmupCommand($client);
         $subCommand->setApplication($this->getApplication() ?? new Console\Application());
 
         // Initialize sub command input

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -139,6 +139,25 @@ final class Configuration
         }
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function getParserClientOptions(): array
+    {
+        try {
+            $json = $this->configuration->get(Extension::KEY, 'parserClientOptions');
+
+            // Early return if no parser client options are configured
+            if (!\is_string($json) || $json === '') {
+                return [];
+            }
+
+            return $this->crawlerFactory->parseCrawlerOptions($json);
+        } catch (Core\Exception) {
+            return [];
+        }
+    }
+
     public function getLimit(): int
     {
         try {

--- a/Classes/Service/CacheWarmupService.php
+++ b/Classes/Service/CacheWarmupService.php
@@ -82,7 +82,7 @@ final class CacheWarmupService
         $crawlingStrategy = $this->createCrawlingStrategy($strategy);
         $cacheWarmer = new CacheWarmup\CacheWarmer(
             $limit ?? $this->configuration->getLimit(),
-            $this->clientFactory->get(),
+            $this->clientFactory->get($this->configuration->getParserClientOptions()),
             $this->crawler,
             $crawlingStrategy,
             true,

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -63,6 +63,21 @@ Crawler
     the :php:interface:`EliasHaeussler\\CacheWarmup\\Crawler\\ConfigurableCrawlerInterface`.
     For more information read :ref:`configurable-crawlers`.
 
+..  _extconf-parserClientOptions:
+
+..  confval:: parserClientOptions
+
+    :type: string (JSON)
+
+    ..  versionadded:: 1.2.0
+
+        `Feature: #502 - Allow configuration of XML parser client options <https://github.com/eliashaeussler/typo3-warming/pull/502>`__
+
+    JSON-encoded string of options for the client used within the XML parser to parse
+    XML sitemaps. All available `Guzzle client options <https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client>`__
+    are accepted and merged with :ref:`TYPO3's global client configuration <t3coreapi:typo3ConfVars_http>`
+    stored in `$GLOBALS['TYPO3_CONF_VARS']['HTTP']`.
+
 ..  _extension-configuration-options:
 
 Options

--- a/Tests/Functional/Command/WarmupCommandTest.php
+++ b/Tests/Functional/Command/WarmupCommandTest.php
@@ -91,7 +91,7 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
     }
 
     #[Framework\Attributes\Test]
-    public function executeThrowsExceptionIfNeitherPagesNotSitesArePassed(): void
+    public function executeThrowsExceptionIfNeitherPagesNorSitesArePassed(): void
     {
         $this->expectException(Console\Exception\RuntimeException::class);
         $this->expectExceptionMessage('Neither sitemaps nor URLs are defined.');
@@ -256,6 +256,25 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
 
         self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
         self::assertEquals(['foo' => 'baz'], Tests\Functional\Fixtures\Classes\DummyVerboseCrawler::$options);
+
+        $this->extensionConfiguration->set(Src\Extension::KEY, $originalConfiguration);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeRespectsParserClientOptions(): void
+    {
+        $originalConfiguration = $this->extensionConfiguration->get(Src\Extension::KEY);
+        $newConfiguration = $originalConfiguration;
+        $newConfiguration['parserClientOptions'] = '{"foo":"baz"}';
+
+        $this->extensionConfiguration->set(Src\Extension::KEY, $newConfiguration);
+
+        $this->commandTester->execute([
+            '--pages' => ['1'],
+        ]);
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertEquals('baz', $this->guzzleClientFactory->lastOptions['foo'] ?? null);
 
         $this->extensionConfiguration->set(Src\Extension::KEY, $originalConfiguration);
     }

--- a/Tests/Functional/Configuration/ConfigurationTest.php
+++ b/Tests/Functional/Configuration/ConfigurationTest.php
@@ -186,6 +186,42 @@ final class ConfigurationTest extends TestingFramework\Core\Functional\Functiona
     }
 
     #[Framework\Attributes\Test]
+    public function getParserClientOptionsReturnsEmptyArrayIfNoParserClientOptionsAreConfigured(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY);
+
+        self::assertSame([], $this->subject->getParserClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getParserClientOptionsReturnsEmptyArrayIfConfiguredParserClientOptionsAreOfInvalidType(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY, ['parserClientOptions' => ['foo' => 'baz']]);
+
+        self::assertSame([], $this->subject->getParserClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getParserClientOptionsThrowsExceptionIfConfiguredParserClientOptionsAreOfInvalidJson(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY, ['parserClientOptions' => '"foo"']);
+
+        $this->expectExceptionObject(
+            CacheWarmup\Exception\InvalidCrawlerOptionException::forInvalidType('"foo"'),
+        );
+
+        $this->subject->getParserClientOptions();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getParserClientOptionsReturnsConfiguredParserClientOptions(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY, ['parserClientOptions' => '{"foo":"baz"}']);
+
+        self::assertSame(['foo' => 'baz'], $this->subject->getParserClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
     public function getLimitReturnsDefaultLimitIfNoLimitIsConfigured(): void
     {
         $this->extensionConfiguration->set(Src\Extension::KEY);

--- a/Tests/Functional/Fixtures/Classes/DummyGuzzleClientFactory.php
+++ b/Tests/Functional/Fixtures/Classes/DummyGuzzleClientFactory.php
@@ -39,6 +39,11 @@ final class DummyGuzzleClientFactory extends Core\Http\Client\GuzzleClientFactor
 {
     public readonly Handler\MockHandler $handler;
 
+    /**
+     * @var array<string, mixed>
+     */
+    public array $lastOptions = [];
+
     public function __construct()
     {
         $this->handler = new Handler\MockHandler();
@@ -46,6 +51,9 @@ final class DummyGuzzleClientFactory extends Core\Http\Client\GuzzleClientFactor
 
     public function getClient(): ClientInterface
     {
-        return new Client(['handler' => $this->handler]);
+        $httpOptions = $this->lastOptions = $GLOBALS['TYPO3_CONF_VARS']['HTTP'];
+        $httpOptions['handler'] = $this->handler;
+
+        return new Client($httpOptions);
     }
 }

--- a/Tests/Functional/Service/CacheWarmupServiceTest.php
+++ b/Tests/Functional/Service/CacheWarmupServiceTest.php
@@ -51,6 +51,7 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
         'EXTENSIONS' => [
             'warming' => [
                 'crawler' => Tests\Functional\Fixtures\Classes\DummyCrawler::class,
+                'parserClientOptions' => '{"foo":"baz"}',
             ],
         ],
     ];
@@ -196,6 +197,18 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
 
         self::assertEquals(new Src\Result\CacheWarmupResult($cacheWarmupResult), $actual);
         self::assertEquals($expected, Tests\Functional\Fixtures\Classes\DummyCrawler::$crawledUrls);
+    }
+
+    #[Framework\Attributes\Test]
+    public function warmupRespectsParserClientOptions(): void
+    {
+        $this->mockSitemapResponse('en');
+
+        $this->subject->warmup([
+            new Src\ValueObject\Request\SiteWarmupRequest($this->site),
+        ]);
+
+        self::assertEquals('baz', $this->guzzleClientFactory->lastOptions['foo'] ?? null);
     }
 
     #[Framework\Attributes\Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,6 +13,9 @@ verboseCrawler = EliasHaeussler\Typo3Warming\Crawler\OutputtingUserAgentCrawler
 # cat=basic/crawler/40; type=string; label=Verbose crawler options (JSON-encoded string):Provide crawler options for the verbose crawler. Applies only if the verbose crawler implements the interface "EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface".
 verboseCrawlerOptions =
 
+# cat=basic/crawler/50; type=string; label=XML parser client options (JSON-encoded string):Provide options for the client used within the XML parser to parse XML sitemaps.
+parserClientOptions =
+
 # cat=basic/options/10; type=int+; label=Crawl limit:Define maximum number of pages to crawl in one iteration. Set to "0" to disable the limit.
 limit = 250
 


### PR DESCRIPTION
This PR introduces a new extension configuration `parserClientOptions`. It accepts a JSON-encoded string of Guzzle client options which is passed to the client used within the XML parser to parse XML sitemaps.