### PR TITLE
[BUGFIX] Assure XDEBUG_MODE is set when running tests with coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,6 +162,7 @@
 			"codecept run --steps"
 		],
 		"test:coverage": [
+			"@putenv XDEBUG_MODE=coverage",
 			"@test:coverage:acceptance",
 			"@test:coverage:functional",
 			"@test:coverage:unit",


### PR DESCRIPTION
This PR fixes a bug with latest xdebug version where a globally configured `XDEBUG_MODE` is not properly respected. It can be reverted once a dedicated xdebug release is pushed and included in DDEV.