### PR TITLE
[BUGFIX] Assure latest version of Xdebug is used for test coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,7 +90,7 @@ jobs:
           autostart: false
       - name: Configure and start DDEV
         run: |
-          ddev config --project-type=typo3 --php-version=8.3 --xdebug-enabled=true --webimage-extra-packages=
+          ddev config --project-type=typo3 --php-version=8.3 --xdebug-enabled=true --webimage-extra-packages=php8.3-xdebug
           ddev start
 
       # Install dependencies


### PR DESCRIPTION
This PR explicitly adds the `php8.3-xdebug` package to DDEV's web container when running the test coverage workflow job. This ensures the latest version of Xdebug is used while testing.