### PR TITLE
[BUGFIX] Specify correct return type for `renderRoot()` implementations

### DIFF
--- a/Resources/Private/Frontend/src/scripts/backend/modal/element/report-panel.ts
+++ b/Resources/Private/Frontend/src/scripts/backend/modal/element/report-panel.ts
@@ -43,7 +43,7 @@ export class ReportPanel extends LitElement {
     this.id = `tx-warming-report-panel-${StringHelper.generateUniqueId()}`;
   }
 
-  createRenderRoot(): Element {
+  createRenderRoot(): HTMLElement {
     // Avoid shadow DOM for Bootstrap CSS to be applied
     return this;
   }

--- a/Resources/Private/Frontend/src/scripts/backend/modal/element/report-summary-card.ts
+++ b/Resources/Private/Frontend/src/scripts/backend/modal/element/report-summary-card.ts
@@ -37,7 +37,7 @@ export class ReportSummaryCard extends LitElement {
   @property({ type: Number }) currentNumber: number;
   @property({ type: Number }) totalNumber: number = null;
 
-  createRenderRoot(): Element {
+  createRenderRoot(): HTMLElement {
     // Avoid shadow DOM for Bootstrap CSS to be applied
     return this;
   }

--- a/Resources/Private/Frontend/src/scripts/backend/modal/progress-modal.ts
+++ b/Resources/Private/Frontend/src/scripts/backend/modal/progress-modal.ts
@@ -62,7 +62,7 @@ export class ProgressModal extends LitElement {
     this.modal = Modal.currentModal;
   }
 
-  protected createRenderRoot(): Element {
+  protected createRenderRoot(): HTMLElement {
     return this;
   }
 

--- a/Resources/Private/Frontend/src/scripts/backend/modal/report-modal.ts
+++ b/Resources/Private/Frontend/src/scripts/backend/modal/report-modal.ts
@@ -43,7 +43,7 @@ export class ReportModal extends LitElement {
     super();
   }
 
-  protected createRenderRoot(): Element {
+  protected createRenderRoot(): HTMLElement {
     // Avoid shadow DOM for Bootstrap CSS to be applied
     return this;
   }

--- a/Resources/Private/Frontend/src/scripts/backend/modal/sites-modal.ts
+++ b/Resources/Private/Frontend/src/scripts/backend/modal/sites-modal.ts
@@ -92,7 +92,7 @@ export class SitesModal extends LitElement {
     this.modal = Modal.currentModal;
   }
 
-  protected createRenderRoot(): Element {
+  protected createRenderRoot(): HTMLElement {
     // Avoid shadow DOM for Bootstrap CSS to be applied
     return this;
   }


### PR DESCRIPTION
This PR changes the return type of custom `Lit` element implementations to always return an instance of `HTMLElement` classes. This is necessary to be in line with recent method signature changes in `Lit`.