### PR TITLE
[TASK] Use Node 20 in DDEV and GitHub workflows

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -24,7 +24,7 @@ web_environment:
     - typo3DatabaseUsername=root
     - typo3DatabasePassword=root
     - typo3DatabaseName=db
-nodejs_version: "16"
+nodejs_version: "20"
 
 # Key features of ddev's config.yaml:
 

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -14,6 +14,14 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.REBUILD_ASSETS_TOKEN }}
 
+      # Prepare environment
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: 'Resources/Private/Frontend/yarn.lock'
+
       # Install Frontend dependencies
       - name: Install Frontend dependencies
         run: yarn --cwd Resources/Private/Frontend --frozen-lockfile

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -21,6 +21,12 @@ jobs:
           php-version: 8.3
           tools: composer:v2, composer-require-checker, composer-unused, cs2pr
           coverage: none
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: 'Resources/Private/Frontend/yarn.lock'
 
       # Validation
       - name: Validate composer.json


### PR DESCRIPTION
This PR explicitly sets the Node.js version to `20`, both in DDEV web server as well as GitHub workflows relying on Frontend asset handling.