### PR TITLE
[BUGFIX] Use PHP 8.2 for test coverage job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.2
           tools: composer:v2
           coverage: none
 
@@ -90,7 +90,7 @@ jobs:
           autostart: false
       - name: Configure and start DDEV
         run: |
-          ddev config --project-type=typo3 --php-version=8.3 --xdebug-enabled=true --webimage-extra-packages=
+          ddev config --project-type=typo3 --xdebug-enabled=true
           ddev start
 
       # Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,6 @@
 			"codecept run --steps"
 		],
 		"test:coverage": [
-			"@putenv XDEBUG_MODE=coverage",
 			"@test:coverage:acceptance",
 			"@test:coverage:functional",
 			"@test:coverage:unit",


### PR DESCRIPTION
This PR switches back to PHP 8.2 in test coverage job since using PHP 8.3 is erroneous.