### PR TITLE
[TASK] Retry failing tests multiple times in CI

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -43,8 +43,6 @@ jobs:
       # Check Composer dependencies
       - name: Check dependencies
         run: composer-require-checker check --config-file dependency-checker.json
-      - name: Reset composer.json
-        run: git checkout composer.json composer.lock
       - name: Re-install Composer dependencies
         uses: ramsey/composer-install@v2
       - name: Check for unused dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Run acceptance tests
         uses: nick-fields/retry@v3
         with:
-          max_attempts: 2
+          max_attempts: 3
           retry_on: error
           timeout_minutes: 10
           command: ddev composer test:acceptance
@@ -106,7 +106,7 @@ jobs:
       - name: Run tests
         uses: nick-fields/retry@v3
         with:
-          max_attempts: 2
+          max_attempts: 3
           retry_on: error
           timeout_minutes: 10
           command: ddev composer test:coverage


### PR DESCRIPTION
This PR changes the retry of failing tests in test workflow from one retry to two retries. This should stabilize test workflow a little bit (hopefully).