### PR TITLE
[FEATURE] Support config files in cache warmup command

### DIFF
--- a/Documentation/Usage/ConsoleCommands.rst
+++ b/Documentation/Usage/ConsoleCommands.rst
@@ -131,6 +131,47 @@ The following command options are available:
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -l 0 -l 1
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -l 0,1
 
+..  confval:: -c|--config
+
+    :Required: false
+    :type: string
+    :Default: none
+    :Multiple allowed: false
+
+    An external configuration file can be used to provide a more
+    fine-grained configuration for cache warmup. The file path may
+    contain references to extensions (see example below).
+
+    ..  note::
+        Config file options will be merged with command options,
+        whereas command options receive higher priority. It's even
+        possible to use environment variables for configuration. Read
+        more in the `official documentation <https://cache-warmup.dev/configuration.html>`__.
+
+    At the moment, the following file formats are supported:
+
+    -   JSON
+    -   PHP
+    -   YAML
+
+    Example:
+
+    ..  tabs::
+
+        ..  group-tab:: Composer-based installation
+
+            ..  code-block:: bash
+
+                vendor/bin/typo3 warming:cachewarmup --config cache-warmup.yaml
+                vendor/bin/typo3 warming:cachewarmup --config EXT:sitepackage/Configuration/cache-warmup.yaml
+
+        ..  group-tab:: Legacy installation
+
+            ..  code-block:: bash
+
+                typo3/sysext/core/bin/typo3 warming:cachewarmup --config cache-warmup.yaml
+                typo3/sysext/core/bin/typo3 warming:cachewarmup --config EXT:sitepackage/Configuration/cache-warmup.yaml
+
 ..  confval:: --limit
 
     :Required: false

--- a/Tests/Functional/Command/WarmupCommandTest.php
+++ b/Tests/Functional/Command/WarmupCommandTest.php
@@ -91,6 +91,7 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
                 $this->get(Typo3SitemapLocator\Sitemap\SitemapLocator::class),
                 $this->get(Core\Site\SiteFinder::class),
                 $this->eventDispatcher,
+                $this->get(Core\Package\PackageManager::class),
             ),
         );
     }
@@ -188,6 +189,19 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
 
         self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
         self::assertEquals($expected, Tests\Functional\Fixtures\Classes\DummyVerboseCrawler::$crawledUrls);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeRespectsConfigurationFile(): void
+    {
+        $this->commandTester->execute([
+            '--pages' => ['1', '2', '3', '4'],
+            // Provides exclude pattern for all sitemaps and URLs
+            '--config' => 'EXT:warming/Tests/Functional/Fixtures/Files/cache-warmup.yaml',
+        ]);
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertCount(0, Tests\Functional\Fixtures\Classes\DummyVerboseCrawler::$crawledUrls);
     }
 
     #[Framework\Attributes\Test]

--- a/Tests/Functional/Fixtures/Files/cache-warmup.yaml
+++ b/Tests/Functional/Fixtures/Files/cache-warmup.yaml
@@ -1,0 +1,2 @@
+excludePatterns:
+  - '#.*#'


### PR DESCRIPTION
This PR adds a new command option `-c|--config` to the `warming:cachewarmup` command. It allows to reference an external config file which holds additional configuration options. The new command option is in line with the [official command option](https://cache-warmup.dev/config-reference/config.html).