### PR TITLE
[FEATURE] Allow warming up all available sites at once

### DIFF
--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -47,6 +47,7 @@ use TYPO3\CMS\Core;
 final class WarmupCommand extends Console\Command\Command
 {
     private const ALL_LANGUAGES = -1;
+    private const ALL_SITES = 'all';
 
     public function __construct(
         private readonly Http\Client\ClientFactory $clientFactory,
@@ -82,6 +83,9 @@ Both types can also be combined or extended by the specification of one or more 
 If you omit the language option, the caches of all languages of the requested pages and sites
 will be warmed up.
 
+You can also use the special keyword <info>all</info> for <info>sites</info>.
+This will cause all available sites to be warmed up.
+
 Examples:
 
 * <comment>warming:cachewarmup -p 1,2,3</comment>
@@ -102,6 +106,10 @@ Examples:
 * <comment>warming:cachewarmup -s 1 -l 0,1</comment>
   ├─ Sites: <info>Root page ID 1</info> or <info>identifier "main"</info>
   └─ Languages: <info>0 and 1</info>
+
+* <comment>warming:cachewarmup -s all</comment>
+  ├─ Sites: <info>all</info>
+  └─ Languages: <info>all</info>
 
 <info>Additional options</info>
 <info>==================</info>
@@ -360,10 +368,16 @@ HELP
         $resolvedSitemaps = [];
 
         foreach ($sites as $siteList) {
-            foreach (Core\Utility\GeneralUtility::trimExplode(',', $siteList, true) as $site) {
+            $siteList = Core\Utility\GeneralUtility::trimExplode(',', $siteList, true);
+
+            if (in_array(self::ALL_SITES, $siteList, true)) {
+                $siteList = $this->siteFinder->getAllSites();
+            }
+
+            foreach ($siteList as $site) {
                 if (Core\Utility\MathUtility::canBeInterpretedAsInteger($site)) {
                     $site = $this->siteFinder->getSiteByRootPageId((int)$site);
-                } else {
+                } elseif (is_string($site)) {
                     $site = $this->siteFinder->getSiteByIdentifier($site);
                 }
 

--- a/Documentation/Usage/ConsoleCommands.rst
+++ b/Documentation/Usage/ConsoleCommands.rst
@@ -76,13 +76,20 @@ The following command options are available:
 ..  confval:: -s|--sites
 
     :Required: false
-    :type: integer or string (site identifier)
+    :type: integer or string (site identifier or `all`)
     :Default: none
     :Multiple allowed: true
 
     Use this option to provide a list of sites to be warmed up. You
     can either pass the appropriate site identifiers or the site's
     root page IDs.
+
+    ..  versionadded:: 3.1.0
+
+        `Feature: #720 - Allow warming up all available sites at once <https://github.com/eliashaeussler/typo3-warming/pull/720>`__
+
+        You can also pass the special keyword `all` to warm up all
+        available sites at once.
 
     Example:
 
@@ -94,6 +101,7 @@ The following command options are available:
 
                 vendor/bin/typo3 warming:cachewarmup -s my-cool-site
                 vendor/bin/typo3 warming:cachewarmup -s 1
+                vendor/bin/typo3 warming:cachewarmup -s all
 
         ..  group-tab:: Legacy installation
 
@@ -101,6 +109,7 @@ The following command options are available:
 
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -s my-cool-site
                 typo3/sysext/core/bin/typo3 warming:cachewarmup -s 1
+                typo3/sysext/core/bin/typo3 warming:cachewarmup -s all
 
 ..  confval:: -l|--languages
 

--- a/Tests/Functional/Fixtures/Files/sitemap_de_2.xml
+++ b/Tests/Functional/Fixtures/Files/sitemap_de_2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://typo3-testing.local/foo/de/</loc>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://typo3-testing.local/foo/de/subsite-1-l-1</loc>
+        <priority>0.5</priority>
+    </url>
+</urlset>

--- a/Tests/Functional/Fixtures/Files/sitemap_en_2.xml
+++ b/Tests/Functional/Fixtures/Files/sitemap_en_2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://typo3-testing.local/foo/</loc>
+        <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://typo3-testing.local/foo/subsite-1</loc>
+        <priority>0.5</priority>
+    </url>
+    <url>
+        <loc>https://typo3-testing.local/foo/subsite-2</loc>
+        <priority>0.7</priority>
+    </url>
+    <url>
+        <loc>https://typo3-testing.local/foo/subsite-2/subsite-2-1</loc>
+        <priority>0.5</priority>
+    </url>
+</urlset>

--- a/Tests/Functional/Fixtures/Files/sitemap_fr_2.xml
+++ b/Tests/Functional/Fixtures/Files/sitemap_fr_2.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+</urlset>

--- a/Tests/Functional/SiteTrait.php
+++ b/Tests/Functional/SiteTrait.php
@@ -33,10 +33,10 @@ use TYPO3\CMS\Core;
  */
 trait SiteTrait
 {
-    private static string $testSiteIdentifier = 'test-site';
-
-    private function createSite(string $baseUrl = 'https://typo3-testing.local/'): Core\Site\Entity\Site
-    {
+    private function createSite(
+        string $baseUrl = 'https://typo3-testing.local/',
+        string $identifier = 'test-site',
+    ): Core\Site\Entity\Site {
         $configPath = $this->instancePath . '/typo3conf/sites';
 
         if ((new Core\Information\Typo3Version())->getMajorVersion() >= 13) {
@@ -65,9 +65,9 @@ trait SiteTrait
             );
         }
 
-        $siteWriter->createNewBasicSite(static::$testSiteIdentifier, 1, $baseUrl);
+        $siteWriter->createNewBasicSite($identifier, 1, $baseUrl);
 
-        $rawConfig = $siteConfiguration->load(static::$testSiteIdentifier);
+        $rawConfig = $siteConfiguration->load($identifier);
         $rawConfig['languages'][1] = [
             'title' => 'German',
             'enabled' => true,
@@ -93,9 +93,9 @@ trait SiteTrait
             'languageId' => 2,
         ];
 
-        $siteWriter->write(static::$testSiteIdentifier, $rawConfig);
+        $siteWriter->write($identifier, $rawConfig);
 
-        $site = $siteConfiguration->getAllExistingSites()[static::$testSiteIdentifier] ?? null;
+        $site = $siteConfiguration->getAllExistingSites()[$identifier] ?? null;
 
         self::assertInstanceOf(Core\Site\Entity\Site::class, $site);
 


### PR DESCRIPTION
This PR extends the existing `--sites` command option by a special keyword `all`. When used, all available sites are warmed up.

Resolves: #717