### PR TITLE
[TASK] Update `ddev-selenium-standalone-chrome` add-on to v1.1.0

### DIFF
--- a/.ddev/addon-metadata/ddev-selenium-standalone-chrome/manifest.yaml
+++ b/.ddev/addon-metadata/ddev-selenium-standalone-chrome/manifest.yaml
@@ -1,7 +1,7 @@
 name: ddev-selenium-standalone-chrome
 repository: ddev/ddev-selenium-standalone-chrome
-version: 1.0.5
-install_date: "2024-05-04T14:41:01+02:00"
+version: 1.1.0
+install_date: "2024-10-14T13:04:51+02:00"
 project_files:
     - docker-compose.selenium-chrome.yaml
     - config.selenium-standalone-chrome.yaml

--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -4,7 +4,6 @@
 #
 # This file comes from https://github.com/ddev/ddev-selenium-standalone-chrome
 #
-version: '3.6'
 services:
   selenium-chrome:
     image: seleniarm/standalone-chromium:4.1.4-20220429
@@ -17,6 +16,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTPS_EXPOSE=7900:7900
       - HTTP_EXPOSE=7910:7900
+      - VNC_NO_PASSWORD=1
     external_links:
       - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
     # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",


### PR DESCRIPTION
This PR updates the `ddev/ddev-selenium-standalone-chrome` add-on to the latest version.