### PR TITLE
[FEATURE] Introduce sub request handler

### DIFF
--- a/Classes/Crawler/OutputtingUserAgentCrawler.php
+++ b/Classes/Crawler/OutputtingUserAgentCrawler.php
@@ -27,6 +27,7 @@ use EliasHaeussler\CacheWarmup;
 use EliasHaeussler\Typo3Warming\Configuration;
 use EliasHaeussler\Typo3Warming\Http;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\HandlerStack;
 use Psr\EventDispatcher;
 use Psr\Log;
 use Symfony\Component\Console;
@@ -45,6 +46,7 @@ use TYPO3\CMS\Core;
  *     request_headers: array<string, string>,
  *     request_options: array<string, mixed>,
  *     client_config: array<string, mixed>,
+ *     perform_subrequests: bool,
  * }>
  */
 final class OutputtingUserAgentCrawler extends CacheWarmup\Crawler\AbstractConfigurableCrawler implements CacheWarmup\Crawler\LoggingCrawler, CacheWarmup\Crawler\VerboseCrawler
@@ -57,6 +59,7 @@ final class OutputtingUserAgentCrawler extends CacheWarmup\Crawler\AbstractConfi
 
     private readonly Http\Client\ClientFactory $clientFactory;
     private readonly Configuration\Configuration $configuration;
+    private readonly Http\Client\Handler\SubRequestHandler $subRequestHandler;
     private Console\Output\OutputInterface $output;
 
     public function __construct(
@@ -67,6 +70,7 @@ final class OutputtingUserAgentCrawler extends CacheWarmup\Crawler\AbstractConfi
     ) {
         $this->clientFactory = Core\Utility\GeneralUtility::makeInstance(Http\Client\ClientFactory::class);
         $this->configuration = Core\Utility\GeneralUtility::makeInstance(Configuration\Configuration::class);
+        $this->subRequestHandler = Core\Utility\GeneralUtility::makeInstance(Http\Client\Handler\SubRequestHandler::class);
         $this->logger = $logger;
 
         parent::__construct($options);
@@ -87,6 +91,11 @@ final class OutputtingUserAgentCrawler extends CacheWarmup\Crawler\AbstractConfi
 
         // Create new client
         $client = $this->client ?? $this->clientFactory->get($this->options['client_config']);
+
+        // Inject sub request handler
+        if ($this->options['perform_subrequests'] && !isset($this->options['request_options']['handler'])) {
+            $this->options['request_options']['handler'] = HandlerStack::create($this->subRequestHandler);
+        }
 
         // Create request pool
         $pool = $this->createPool($urls, $client, [$resultHandler, $progressBarHandler, $logHandler]);
@@ -110,6 +119,12 @@ final class OutputtingUserAgentCrawler extends CacheWarmup\Crawler\AbstractConfi
 
         // Use GET instead of HEAD as default request method
         $optionsResolver->setDefault('request_method', 'GET');
+
+        // Add option for sub request handler
+        $optionsResolver->define('perform_subrequests')
+            ->allowedTypes('bool')
+            ->default(false)
+        ;
     }
 
     /**

--- a/Classes/Http/Client/Handler/SubRequestHandler.php
+++ b/Classes/Http/Client/Handler/SubRequestHandler.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\Http\Client\Handler;
+
+use GuzzleHttp\Exception;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Utils;
+use Psr\Http\Message;
+use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Frontend;
+
+/**
+ * SubRequestHandler
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[DependencyInjection\Attribute\Autoconfigure(public: true)]
+final class SubRequestHandler
+{
+    /**
+     * @var list<string>
+     */
+    private readonly array $supportedBaseUrls;
+
+    /**
+     * @var callable(Message\RequestInterface, array<string, mixed>): Promise\PromiseInterface
+     */
+    private $fallbackHandler;
+
+    public function __construct(
+        private readonly Frontend\Http\Application $application,
+        Core\Site\SiteFinder $siteFinder,
+    ) {
+        $this->supportedBaseUrls = $this->resolveBaseUrls($siteFinder);
+        $this->fallbackHandler = Utils::chooseHandler();
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __invoke(Message\RequestInterface $request, array $options): Promise\PromiseInterface
+    {
+        if (!$this->isSupportedRequestUrl($request->getUri())) {
+            return ($this->fallbackHandler)($request, $options);
+        }
+
+        $initialTsfe = $GLOBALS['TSFE'] ?? null;
+        $GLOBALS['TSFE'] = null;
+
+        try {
+            return $this->sendSubRequest($request);
+        } finally {
+            $GLOBALS['TSFE'] = $initialTsfe;
+        }
+    }
+
+    private function sendSubRequest(Message\RequestInterface $request): Promise\PromiseInterface
+    {
+        $subRequest = new Core\Http\ServerRequest(
+            $request->getUri(),
+            $request->getMethod(),
+            $request->getBody(),
+            $request->getHeaders(),
+        );
+
+        try {
+            $response = $this->application->handle($subRequest);
+        } catch (\Exception $exception) {
+            return Promise\Create::rejectionFor(
+                new Exception\RequestException($exception->getMessage(), $request),
+            );
+        }
+
+        return Promise\Create::promiseFor($response);
+    }
+
+    private function isSupportedRequestUrl(Message\UriInterface $uri): bool
+    {
+        $requestUrl = (string)$uri;
+
+        foreach ($this->supportedBaseUrls as $baseUrl) {
+            if (str_starts_with($requestUrl, $baseUrl)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Core\Site\SiteFinder $siteFinder
+     * @return list<string>
+     */
+    private function resolveBaseUrls(Core\Site\SiteFinder $siteFinder): array
+    {
+        $sites = $siteFinder->getAllSites();
+        $baseUrls = [];
+
+        foreach ($sites as $site) {
+            $baseUrls[] = (string)$site->getBase();
+        }
+
+        return $baseUrls;
+    }
+}

--- a/Documentation/Configuration/CrawlerConfiguration.rst
+++ b/Documentation/Configuration/CrawlerConfiguration.rst
@@ -1,0 +1,41 @@
+..  include:: /Includes.rst.txt
+
+..  _crawler-configuration:
+
+=====================
+Crawler configuration
+=====================
+
+The following configuration applies only to the :ref:`default crawlers <default-crawlers>`
+shipped by this extension.
+
+..  seealso::
+
+    If you want to learn more about configurable crawlers, read more in the :ref:`developer corner <crawlers>`.
+
+..  note::
+
+    Both default crawlers utilize the same crawler options that are described in the
+    `option reference <https://cache-warmup.dev/config-reference/crawler-options.html#option-reference>`__
+    of the underlying `eliashaeussler/cache-warmup` library.
+
+In addition, the following crawler options are available:
+
+..  confval:: perform_subrequests
+    :type: boolean
+    :Default: 0
+
+    ..  versionadded:: 3.3.0
+
+        `Feature: #730 - Introduce sub request handler <https://github.com/eliashaeussler/typo3-warming/pull/730>`__
+
+    Enable sub request handler for cache warmup requests. This will significantly increase
+    performance of the whole cache warmup progress, since no HTTP requests will be performed
+    anymore. Instead, the bootstrapped frontend application is re-used for each cache warmup
+    request.
+
+    ..  note::
+
+        Only URLs matching the site's base URL are handled by the sub request handler. All
+        other URLs (e.g. pages linking to external URLs) will be handled by the Guzzle's
+        default handler.

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -19,5 +19,6 @@ Learn what configuration options are available on the following pages:
     ExtensionConfiguration
     SiteConfiguration
     TypoScriptConfiguration
+    CrawlerConfiguration
     Permissions
     Logging

--- a/Tests/CGL/phpstan-baseline.neon
+++ b/Tests/CGL/phpstan-baseline.neon
@@ -121,9 +121,144 @@ parameters:
 			path: ../Functional/Controller/CacheWarmupLegacyControllerTest.php
 
 		-
+			message: "#^Call to method createNewBasicSite\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Call to method write\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory not found\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Instantiated class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter not found\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\Loader\\\\YamlFileLoader\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+
+		-
+			message: "#^Call to method createNewBasicSite\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Call to method write\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory not found\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Instantiated class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter not found\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\Loader\\\\YamlFileLoader\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Crawler/OutputtingUserAgentCrawlerTest.php
+
+		-
 			message: "#^EliasHaeussler\\\\Typo3Warming\\\\Tests\\\\Functional\\\\Fixtures\\\\Classes\\\\DummyPackageManager\\:\\:__construct\\(\\) does not call parent constructor from TYPO3\\\\CMS\\\\Core\\\\Package\\\\PackageManager\\.$#"
 			count: 1
 			path: ../Functional/Fixtures/Classes/DummyPackageManager.php
+
+		-
+			message: "#^Call to method createNewBasicSite\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Call to method write\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory not found\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Instantiated class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter not found\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\Loader\\\\YamlFileLoader\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
+
+		-
+			message: "#^Service \"TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory\" is not registered in the container\\.$#"
+			count: 1
+			path: ../Functional/Http/Client/Handler/SubRequestHandlerTest.php
 
 		-
 			message: "#^Call to method createNewBasicSite\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"

--- a/Tests/Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
+++ b/Tests/Functional/Crawler/ConcurrentUserAgentCrawlerTest.php
@@ -28,7 +28,9 @@ use EliasHaeussler\TransientLogger;
 use EliasHaeussler\Typo3Warming as Src;
 use EliasHaeussler\Typo3Warming\Tests;
 use PHPUnit\Framework;
+use Symfony\Component\DependencyInjection;
 use TYPO3\CMS\Core;
+use TYPO3\CMS\Frontend;
 use TYPO3\TestingFramework;
 
 /**
@@ -41,6 +43,7 @@ use TYPO3\TestingFramework;
 final class ConcurrentUserAgentCrawlerTest extends TestingFramework\Core\Functional\FunctionalTestCase
 {
     use Tests\Functional\ClientMockTrait;
+    use Tests\Functional\SiteTrait;
 
     protected array $testExtensionsToLoad = [
         'sitemap_locator',
@@ -49,18 +52,27 @@ final class ConcurrentUserAgentCrawlerTest extends TestingFramework\Core\Functio
 
     protected bool $initializeDatabase = false;
 
+    private Frontend\Http\Application&Framework\MockObject\MockObject $applicationMock;
     private Src\Crawler\ConcurrentUserAgentCrawler $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->createSite();
+
         $this->guzzleClientFactory = new Tests\Functional\Fixtures\Classes\DummyGuzzleClientFactory();
+        $this->applicationMock = $this->createMock(Frontend\Http\Application::class);
 
         Core\Utility\GeneralUtility::addInstance(
             Src\Http\Client\ClientFactory::class,
             new Src\Http\Client\ClientFactory($this->guzzleClientFactory),
         );
+
+        // Mock frontend application for sub request handling tests
+        $container = $this->getContainer();
+        self::assertInstanceOf(DependencyInjection\ContainerInterface::class, $container);
+        $container->set(Frontend\Http\Application::class, $this->applicationMock);
 
         $this->subject = new Src\Crawler\ConcurrentUserAgentCrawler();
     }
@@ -165,5 +177,26 @@ final class ConcurrentUserAgentCrawlerTest extends TestingFramework\Core\Functio
 
         self::assertCount(1, $logger->getByLogLevel(TransientLogger\Log\LogLevel::Error));
         self::assertCount(1, $logger->getByLogLevel(TransientLogger\Log\LogLevel::Info));
+    }
+
+    #[Framework\Attributes\Test]
+    public function crawlUsesSubRequestHandler(): void
+    {
+        $this->subject->setOptions(['perform_subrequests' => true]);
+
+        $urls = [
+            new Core\Http\Uri('https://typo3-testing.local/'),
+            new Core\Http\Uri('https://typo3-testing.local/de/'),
+        ];
+        $response = new Core\Http\Response();
+
+        $this->applicationMock->method('handle')->willReturn($response);
+
+        $actual = $this->subject->crawl($urls);
+
+        self::assertTrue($actual->isSuccessful());
+        self::assertCount(2, $actual->getSuccessful());
+        self::assertSame(['response' => $response], $actual->getSuccessful()[0]->getData());
+        self::assertSame(['response' => $response], $actual->getSuccessful()[1]->getData());
     }
 }

--- a/Tests/Functional/Http/Client/Handler/SubRequestHandlerTest.php
+++ b/Tests/Functional/Http/Client/Handler/SubRequestHandlerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\Tests\Functional\Http\Client\Handler;
+
+use EliasHaeussler\Typo3Warming as Src;
+use EliasHaeussler\Typo3Warming\Tests;
+use GuzzleHttp\Exception;
+use PHPUnit\Framework;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Frontend;
+use TYPO3\TestingFramework;
+
+/**
+ * SubRequestHandlerTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Http\Client\Handler\SubRequestHandler::class)]
+final class SubRequestHandlerTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    use Tests\Functional\SiteTrait;
+
+    protected array $testExtensionsToLoad = [
+        'sitemap_locator',
+        'warming',
+    ];
+
+    protected bool $initializeDatabase = false;
+
+    private Frontend\Http\Application&Framework\MockObject\MockObject $applicationMock;
+    private Src\Http\Client\Handler\SubRequestHandler $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createSite();
+
+        $this->applicationMock = $this->createMock(Frontend\Http\Application::class);
+        $this->subject = new Src\Http\Client\Handler\SubRequestHandler(
+            $this->applicationMock,
+            $this->get(Core\Site\SiteFinder::class),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function invokeUsesFallbackHandlerIfNoMatchingSitesAreAvailable(): void
+    {
+        $request = new Core\Http\Request('https://typo3-fake.local/', body: 'php://temp');
+
+        $this->applicationMock->expects(self::never())->method('handle');
+
+        ($this->subject)($request, [])->cancel();
+    }
+
+    #[Framework\Attributes\Test]
+    public function invokeReturnsFulfilledPromiseWithResponseFromApplication(): void
+    {
+        $request = new Core\Http\Request('https://typo3-testing.local/', body: 'php://temp');
+        $response = new Core\Http\Response();
+
+        $this->applicationMock->method('handle')->willReturn($response);
+
+        $actual = ($this->subject)($request, [])->wait();
+
+        self::assertSame($response, $actual);
+    }
+
+    #[Framework\Attributes\Test]
+    public function invokeReturnsRejectedPromiseWithExceptionFromApplication(): void
+    {
+        $request = new Core\Http\Request('https://typo3-testing.local/', body: 'php://temp');
+        $exception = new \Exception('something went wrong');
+
+        $this->applicationMock->method('handle')->willThrowException($exception);
+
+        $expected = new Exception\RequestException('something went wrong', $request);
+        $actual = null;
+
+        try {
+            ($this->subject)($request, [])->wait();
+        } catch (\Exception $actual) {
+            // Intentionally left blank.
+        }
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 		"eliashaeussler/sse": "^1.0.1",
 		"eliashaeussler/typo3-sitemap-locator": "^0.1.0",
 		"guzzlehttp/guzzle": "^7.5",
+		"guzzlehttp/promises": "^1.4 || ^2.0",
 		"psr/event-dispatcher": "^1.0",
 		"psr/http-message": "^1.1 || ^2.0",
 		"psr/log": "^1.0 || ^2.0 || ^3.0",
@@ -35,7 +36,8 @@
 		"typo3/cms-backend": "~12.4.8 || ~13.4.0",
 		"typo3/cms-core": "~12.4.8 || ~13.4.0",
 		"typo3/cms-extbase": "~12.4.8 || ~13.4.0",
-		"typo3/cms-fluid": "~12.4.8 || ~13.4.0"
+		"typo3/cms-fluid": "~12.4.8 || ~13.4.0",
+		"typo3/cms-frontend": "~12.4.8 || ~13.4.0"
 	},
 	"require-dev": {
 		"codeception/module-asserts": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce48e9eb947f3abeed2e2b5d513263a0",
+    "content-hash": "5509da708f9ebed58bf2a9e917fb609b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5833,6 +5833,76 @@
             "time": "2024-10-15T08:55:53+00:00"
         },
         {
+            "name": "typo3/cms-frontend",
+            "version": "v12.4.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TYPO3-CMS/frontend.git",
+                "reference": "162c4cd86f3f43a20ae1c218db14a9706a03d416"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/162c4cd86f3f43a20ae1c218db14a9706a03d416",
+                "reference": "162c4cd86f3f43a20ae1c218db14a9706a03d416",
+                "shasum": ""
+            },
+            "require": {
+                "ext-libxml": "*",
+                "typo3/cms-core": "12.4.22"
+            },
+            "conflict": {
+                "typo3/cms": "*"
+            },
+            "suggest": {
+                "typo3/cms-adminpanel": "Provides additional information and functionality for backend users in the frontend."
+            },
+            "type": "typo3-cms-framework",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.4.x-dev"
+                },
+                "typo3/cms": {
+                    "Package": {
+                        "serviceProvider": "TYPO3\\CMS\\Frontend\\ServiceProvider",
+                        "protected": true,
+                        "partOfFactoryDefault": true,
+                        "partOfMinimalUsableSystem": true
+                    },
+                    "extension-key": "frontend"
+                },
+                "typo3/class-alias-loader": {
+                    "class-alias-maps": [
+                        "Migrations/Code/ClassAliasMap.php"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "TYPO3\\CMS\\Frontend\\": "Classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "TYPO3 Core Team",
+                    "email": "typo3cms@typo3.org",
+                    "role": "Developer"
+                }
+            ],
+            "description": "TYPO3 CMS Frontend",
+            "homepage": "https://typo3.org",
+            "support": {
+                "chat": "https://typo3.org/help",
+                "docs": "https://docs.typo3.org",
+                "issues": "https://forge.typo3.org",
+                "source": "https://github.com/typo3/typo3"
+            },
+            "time": "2024-10-15T08:55:53+00:00"
+        },
+        {
             "name": "typo3/html-sanitizer",
             "version": "v2.2.0",
             "source": {
@@ -9025,76 +9095,6 @@
             "time": "2024-03-03T12:36:25+00:00"
         },
         {
-            "name": "typo3/cms-frontend",
-            "version": "v12.4.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/TYPO3-CMS/frontend.git",
-                "reference": "162c4cd86f3f43a20ae1c218db14a9706a03d416"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3-CMS/frontend/zipball/162c4cd86f3f43a20ae1c218db14a9706a03d416",
-                "reference": "162c4cd86f3f43a20ae1c218db14a9706a03d416",
-                "shasum": ""
-            },
-            "require": {
-                "ext-libxml": "*",
-                "typo3/cms-core": "12.4.22"
-            },
-            "conflict": {
-                "typo3/cms": "*"
-            },
-            "suggest": {
-                "typo3/cms-adminpanel": "Provides additional information and functionality for backend users in the frontend."
-            },
-            "type": "typo3-cms-framework",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "12.4.x-dev"
-                },
-                "typo3/cms": {
-                    "Package": {
-                        "serviceProvider": "TYPO3\\CMS\\Frontend\\ServiceProvider",
-                        "protected": true,
-                        "partOfFactoryDefault": true,
-                        "partOfMinimalUsableSystem": true
-                    },
-                    "extension-key": "frontend"
-                },
-                "typo3/class-alias-loader": {
-                    "class-alias-maps": [
-                        "Migrations/Code/ClassAliasMap.php"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TYPO3\\CMS\\Frontend\\": "Classes/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "TYPO3 Core Team",
-                    "email": "typo3cms@typo3.org",
-                    "role": "Developer"
-                }
-            ],
-            "description": "TYPO3 CMS Frontend",
-            "homepage": "https://typo3.org",
-            "support": {
-                "chat": "https://typo3.org/help",
-                "docs": "https://docs.typo3.org",
-                "issues": "https://forge.typo3.org",
-                "source": "https://github.com/typo3/typo3"
-            },
-            "time": "2024-10-15T08:55:53+00:00"
-        },
-        {
             "name": "typo3/cms-install",
             "version": "v12.4.22",
             "source": {
@@ -9359,13 +9359,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-json": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This PR introduces a `SubRequestHandler`. It can be used in the default crawlers to perform cache warmup requests with the bootstrapped frontend application instead of sending real HTTP requests.