### PR TITLE
[TASK] Migrate deprecated sass `@import` statement

### DIFF
--- a/Resources/Private/Frontend/rollup.config.js
+++ b/Resources/Private/Frontend/rollup.config.js
@@ -93,7 +93,7 @@ export default [
       }),
       postcss({
         extract: 'backend.css',
-        minimize: isDev ? false: minimizeOptions,
+        minimize: isDev ? false : minimizeOptions,
         sourceMap: isDev ? 'inline' : false,
         use: ['sass'],
       }),

--- a/Resources/Private/Frontend/src/styles/modal.scss
+++ b/Resources/Private/Frontend/src/styles/modal.scss
@@ -17,8 +17,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-@import 'modal/common';
-@import 'modal/alert';
-@import 'modal/progress';
-@import 'modal/report';
-@import 'modal/sites';
+@use 'modal/common';
+@use 'modal/alert';
+@use 'modal/progress';
+@use 'modal/report';
+@use 'modal/sites';


### PR DESCRIPTION
The [`@import` statement is deprecated](https://sass-lang.com/documentation/breaking-changes/import/) and will be removed with Dart Sass 2.0. Thus, it is now migrated to its successor `@use`.