### PR TITLE
[BUGFIX] Remove default value for `tx_warming_domain_model_log.url`

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,7 +1,7 @@
 CREATE TABLE tx_warming_domain_model_log (
 	request_id varchar(50) default '' not null,
 	date int(10) unsigned default '0' not null,
-	url text default '' not null,
+	url text not null,
 	message mediumtext,
 	state varchar(20) default '' not null,
 	sitemap text,


### PR DESCRIPTION
This PR removes the default value for `tx_warming_domain_model_log.url` since DBMSs like MySQL don't support default values for `TEXT` columns.

Resolves: #729