### PR TITLE
[TASK] Use current backend user by default in `PermissionContext`

### DIFF
--- a/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
+++ b/Classes/Backend/ContextMenu/ItemProviders/CacheWarmupProvider.php
@@ -121,10 +121,7 @@ final class CacheWarmupProvider extends Backend\ContextMenu\ItemProviders\PagePr
             return $this->canWarmupCachesOfSite();
         }
 
-        return $this->permissionGuard->canWarmupCacheOfPage(
-            (int)$this->identifier,
-            Security\Context\PermissionContext::forCurrentBackendUser(),
-        );
+        return $this->permissionGuard->canWarmupCacheOfPage((int)$this->identifier);
     }
 
     /**
@@ -182,7 +179,7 @@ final class CacheWarmupProvider extends Backend\ContextMenu\ItemProviders\PagePr
                     $languages,
                     fn(Core\Site\Entity\SiteLanguage $siteLanguage): bool => $this->permissionGuard->canWarmupCacheOfPage(
                         (int)$this->identifier,
-                        Security\Context\PermissionContext::forLanguageAndCurrentBackendUser($siteLanguage->getLanguageId()),
+                        new Security\Context\PermissionContext($siteLanguage->getLanguageId()),
                     ),
                 );
             }

--- a/Classes/Domain/Repository/SiteLanguageRepository.php
+++ b/Classes/Domain/Repository/SiteLanguageRepository.php
@@ -85,7 +85,7 @@ final class SiteLanguageRepository
 
     private function isAccessible(Core\Site\Entity\Site $site, Core\Site\Entity\SiteLanguage $siteLanguage): bool
     {
-        $context = Security\Context\PermissionContext::forLanguageAndCurrentBackendUser($siteLanguage->getLanguageId());
+        $context = new Security\Context\PermissionContext($siteLanguage->getLanguageId());
 
         return !$this->isExcluded($siteLanguage) && $this->permissionGuard->canWarmupCacheOfSite($site, $context);
     }

--- a/Classes/Domain/Repository/SiteRepository.php
+++ b/Classes/Domain/Repository/SiteRepository.php
@@ -115,9 +115,7 @@ final class SiteRepository
 
     private function isAccessible(Core\Site\Entity\Site $site): bool
     {
-        $context = Security\Context\PermissionContext::forCurrentBackendUser();
-
-        return !$this->isExcluded($site) && $this->permissionGuard->canWarmupCacheOfSite($site, $context);
+        return !$this->isExcluded($site) && $this->permissionGuard->canWarmupCacheOfSite($site);
     }
 
     private function isExcluded(Core\Site\Entity\Site $site): bool

--- a/Classes/Security/Context/PermissionContext.php
+++ b/Classes/Security/Context/PermissionContext.php
@@ -34,18 +34,12 @@ use TYPO3\CMS\Core;
  */
 final class PermissionContext
 {
+    public readonly Core\Authentication\BackendUserAuthentication $backendUser;
+
     public function __construct(
         public readonly ?int $languageId = null,
-        public readonly ?Core\Authentication\BackendUserAuthentication $backendUser = null,
-    ) {}
-
-    public static function forLanguageAndCurrentBackendUser(int $languageId): self
-    {
-        return new self($languageId, Utility\BackendUtility::getBackendUser());
-    }
-
-    public static function forCurrentBackendUser(): self
-    {
-        return new self(backendUser: Utility\BackendUtility::getBackendUser());
+        ?Core\Authentication\BackendUserAuthentication $backendUser = null,
+    ) {
+        $this->backendUser = $backendUser ?? Utility\BackendUtility::getBackendUser();
     }
 }

--- a/Classes/Security/WarmupPermissionGuard.php
+++ b/Classes/Security/WarmupPermissionGuard.php
@@ -91,11 +91,6 @@ final class WarmupPermissionGuard
             return false;
         }
 
-        // Early return if no backend user rights should be checked
-        if ($context->backendUser === null) {
-            return true;
-        }
-
         // Early return if backend user has admin privileges
         if ($context->backendUser->isAdmin()) {
             return true;
@@ -106,7 +101,7 @@ final class WarmupPermissionGuard
 
     private function hasLanguageAccess(Context\PermissionContext $context): bool
     {
-        if ($context->languageId === null || $context->backendUser === null) {
+        if ($context->languageId === null) {
             return true;
         }
 
@@ -119,10 +114,6 @@ final class WarmupPermissionGuard
 
     private function isAllowedPage(int $pageId, Context\PermissionContext $context): bool
     {
-        if ($context->backendUser === null) {
-            return true;
-        }
-
         if ($context->backendUser->isAdmin()) {
             return true;
         }
@@ -164,10 +155,6 @@ final class WarmupPermissionGuard
 
     private function isAllowedSite(string $siteIdentifier, Context\PermissionContext $context): bool
     {
-        if ($context->backendUser === null) {
-            return true;
-        }
-
         if ($context->backendUser->isAdmin()) {
             return true;
         }

--- a/Tests/Functional/Security/Context/PermissionContextTest.php
+++ b/Tests/Functional/Security/Context/PermissionContextTest.php
@@ -44,22 +44,12 @@ final class PermissionContextTest extends TestingFramework\Core\Functional\Funct
     }
 
     #[Framework\Attributes\Test]
-    public function forLanguageAndCurrentBackendUserReturnsContextForGivenLanguageAndCurrentBackendUser(): void
+    public function constructorUsesCurrentBackendUserIfNoBackendUserGiven(): void
     {
         $backendUser = $this->setUpBackendUser(3);
 
-        $expected = new Src\Security\Context\PermissionContext(1, $backendUser);
+        $actual = new Src\Security\Context\PermissionContext();
 
-        self::assertEquals($expected, Src\Security\Context\PermissionContext::forLanguageAndCurrentBackendUser(1));
-    }
-
-    #[Framework\Attributes\Test]
-    public function forCurrentBackendUserReturnsContextForCurrentBackendUser(): void
-    {
-        $backendUser = $this->setUpBackendUser(3);
-
-        $expected = new Src\Security\Context\PermissionContext(backendUser: $backendUser);
-
-        self::assertEquals($expected, Src\Security\Context\PermissionContext::forCurrentBackendUser());
+        self::assertEquals($backendUser, $actual->backendUser);
     }
 }

--- a/Tests/Functional/Security/WarmupPermissionGuardTest.php
+++ b/Tests/Functional/Security/WarmupPermissionGuardTest.php
@@ -52,6 +52,8 @@ final class WarmupPermissionGuardTest extends TestingFramework\Core\Functional\F
         $this->importCSVDataSet(\dirname(__DIR__) . '/Fixtures/Database/be_users.csv');
         $this->importCSVDataSet(\dirname(__DIR__) . '/Fixtures/Database/pages.csv');
 
+        $this->setUpBackendUser(3);
+
         $this->site = $this->createSite();
         $this->cache = $this->get('cache.runtime');
         $this->subject = new Src\Security\WarmupPermissionGuard($this->cache);
@@ -85,8 +87,7 @@ final class WarmupPermissionGuardTest extends TestingFramework\Core\Functional\F
     #[Framework\Attributes\Test]
     public function canWarmupCacheOfPageReturnsTrueForAdmins(): void
     {
-        $backendUser = $this->setUpBackendUser(3);
-        $context = new Src\Security\Context\PermissionContext(backendUser: $backendUser);
+        $context = new Src\Security\Context\PermissionContext();
 
         self::assertTrue($this->subject->canWarmupCacheOfPage(1, $context));
     }
@@ -130,8 +131,7 @@ final class WarmupPermissionGuardTest extends TestingFramework\Core\Functional\F
     #[Framework\Attributes\Test]
     public function canWarmupCacheOfPageReturnsFalseForPageWithoutTranslation(): void
     {
-        $backendUser = $this->setUpBackendUser(3);
-        $context = new Src\Security\Context\PermissionContext(1, $backendUser);
+        $context = new Src\Security\Context\PermissionContext(1);
 
         self::assertFalse($this->subject->canWarmupCacheOfPage(3, $context));
     }
@@ -143,12 +143,6 @@ final class WarmupPermissionGuardTest extends TestingFramework\Core\Functional\F
         $context = new Src\Security\Context\PermissionContext(1, $backendUser);
 
         self::assertFalse($this->subject->canWarmupCacheOfPage(1, $context));
-    }
-
-    #[Framework\Attributes\Test]
-    public function canWarmupCacheOfPageReturnsTrueIfUserIsOmittedInContext(): void
-    {
-        self::assertTrue($this->subject->canWarmupCacheOfPage(2));
     }
 
     #[Framework\Attributes\Test]
@@ -177,8 +171,7 @@ final class WarmupPermissionGuardTest extends TestingFramework\Core\Functional\F
     #[Framework\Attributes\Test]
     public function canWarmupCacheOfSiteReturnsTrueForAdmins(): void
     {
-        $backendUser = $this->setUpBackendUser(3);
-        $context = new Src\Security\Context\PermissionContext(backendUser: $backendUser);
+        $context = new Src\Security\Context\PermissionContext();
 
         self::assertTrue($this->subject->canWarmupCacheOfSite($this->site, $context));
     }
@@ -204,8 +197,7 @@ final class WarmupPermissionGuardTest extends TestingFramework\Core\Functional\F
     #[Framework\Attributes\Test]
     public function canWarmupCacheOfSiteWithGivenLanguageReturnsTrueForAdmins(): void
     {
-        $backendUser = $this->setUpBackendUser(3);
-        $context = new Src\Security\Context\PermissionContext(1, $backendUser);
+        $context = new Src\Security\Context\PermissionContext(1);
 
         self::assertTrue($this->subject->canWarmupCacheOfSite($this->site, $context));
     }
@@ -217,11 +209,5 @@ final class WarmupPermissionGuardTest extends TestingFramework\Core\Functional\F
         $context = new Src\Security\Context\PermissionContext(2, $backendUser);
 
         self::assertFalse($this->subject->canWarmupCacheOfSite($this->site, $context));
-    }
-
-    #[Framework\Attributes\Test]
-    public function canWarmupCacheOfSiteReturnsTrueIfUserIsOmittedInContext(): void
-    {
-        self::assertTrue($this->subject->canWarmupCacheOfSite($this->site));
     }
 }


### PR DESCRIPTION
With this PR, the current backend user is now used by default in `PermissionContext` if no explicit user is defined.