### PR TITLE
[FEATURE] Introduce client options extension configuration

### DIFF
--- a/Classes/Http/Client/ClientBridge.php
+++ b/Classes/Http/Client/ClientBridge.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Warming\Http\Client;
 
 use EliasHaeussler\CacheWarmup;
+use EliasHaeussler\Typo3Warming\Configuration;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Psr\EventDispatcher;
@@ -41,6 +42,7 @@ final class ClientBridge
     private ?ClientInterface $client = null;
 
     public function __construct(
+        private readonly Configuration\Configuration $configuration,
         private readonly Core\Http\Client\GuzzleClientFactory $guzzleClientFactory,
         private readonly EventDispatcher\EventDispatcherInterface $eventDispatcher,
     ) {}
@@ -57,7 +59,12 @@ final class ClientBridge
     {
         $this->client ??= $this->guzzleClientFactory->getClient();
 
-        return $this->getClientConfigFromReflection($this->client);
+        $configFromClient = $this->getClientConfigFromReflection($this->client);
+        $configFromExtension = $this->configuration->getClientOptions();
+
+        Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($configFromClient, $configFromExtension);
+
+        return $configFromClient;
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -44,5 +44,7 @@ services:
 
   EliasHaeussler\CacheWarmup\Config\Component\OptionsParser:
   EliasHaeussler\CacheWarmup\Crawler\CrawlerFactory:
+    # Must be public for use with GU::mI in Configuration class to avoid circular dependencies
+    public: true
   EliasHaeussler\CacheWarmup\Crawler\Strategy\CrawlingStrategyFactory:
   EliasHaeussler\CacheWarmup\DependencyInjection\ContainerFactory:

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -35,6 +35,11 @@ Crawler
     :php:interface:`\EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler`
     interface. For more information read :ref:`configurable-crawlers`.
 
+    ..  important::
+
+        Client-related configuration was moved to :ref:`clientOptions <extconf-clientOptions>`
+        in :ref:`version 4.0.0 <version-4.0.0>`.
+
 ..  _extconf-verboseCrawler:
 
 ..  confval:: verboseCrawler
@@ -58,6 +63,16 @@ Crawler
     the :php:interface:`\EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler` interface.
     For more information read :ref:`configurable-crawlers`.
 
+    ..  important::
+
+        Client-related configuration was moved to :ref:`clientOptions <extconf-clientOptions>`
+        in :ref:`version 4.0.0 <version-4.0.0>`.
+
+..  _extension-configuration-parser:
+
+Parser
+======
+
 ..  _extconf-parserOptions:
 
 ..  confval:: parserOptions
@@ -70,10 +85,41 @@ Crawler
     ..  important::
 
         This configuration was renamed from `parserClientOptions` to `parserOptions`
-        in :ref:`version 4.0.0 <version-4.0.0>`.
+        in :ref:`version 4.0.0 <version-4.0.0>`. Migrate existing configuration to
+        :ref:`clientOptions <extconf-clientOptions>`
 
     JSON-encoded string of parser options used within the XML parser to parse
     XML sitemaps. For more information read :ref:`parser-configuration`.
+
+..  _extension-configuration-client:
+
+Client
+======
+
+..  _extconf-clientOptions:
+
+..  confval:: clientOptions
+    :type: string (JSON)
+
+    ..  versionadded:: 4.0.0
+
+        `Feature: #844 - Introduce client options extension configuration <https://github.com/eliashaeussler/typo3-warming/pull/844>`__
+
+    JSON-encoded string of options for the client used within the crawler and XML parser
+    to parse and crawl XML sitemaps. All available
+    `Guzzle client options <https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client>`__
+    are accepted and merged with :ref:`TYPO3's global client configuration <t3coreapi:typo3ConfVars_http>`
+    stored in `$GLOBALS['TYPO3_CONF_VARS']['HTTP']`.
+
+    ..  tip::
+
+        If the XML sitemap is protected by HTTP authentication (basic auth), you can set the
+        credentials as follows: :json:`{"auth": ["<username>", "<password>"]}`
+
+        In case the XML sitemap does not have a valid SSL certificate, it is possible to disable
+        the SSL verification: :json:`{"verify": false}`
+
+        You can also combine both settings: :json:`{"auth": ["<username>", "<password>"], "verify": false}`
 
 ..  _extension-configuration-options:
 

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -22,6 +22,11 @@ Version 4.0.0
 Upgrade of `eliashaeussler/cache-warmup` library
 ------------------------------------------------
 
+-   Crawler option `client_config` is removed and must be migrated to
+    extension configuration :ref:`clientOptions <confval-clientoptions>`.
+-   Extension configuration `parserClientOptions` is renamed to
+    :ref:`parserOptions <confval-parseroptions>`. Existing configuration must
+    be migrated to extension configuration :ref:`clientOptions <confval-clientoptions>`.
 -   Crawling response body is no longer attached to response objects. Enable
     crawler option `write_response_body` to restore previous behavior.
 -   Read more in the library's `release notes <https://github.com/eliashaeussler/cache-warmup/releases/tag/4.0.0>`__.

--- a/Tests/Functional/Configuration/ConfigurationTest.php
+++ b/Tests/Functional/Configuration/ConfigurationTest.php
@@ -222,6 +222,42 @@ final class ConfigurationTest extends TestingFramework\Core\Functional\Functiona
     }
 
     #[Framework\Attributes\Test]
+    public function getClientOptionsReturnsEmptyArrayIfNoClientOptionsAreConfigured(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY);
+
+        self::assertSame([], $this->subject->getClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getClientOptionsReturnsEmptyArrayIfConfiguredClientOptionsAreOfInvalidType(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY, ['clientOptions' => ['foo' => 'baz']]);
+
+        self::assertSame([], $this->subject->getClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getClientOptionsThrowsExceptionIfConfiguredClientOptionsAreOfInvalidJson(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY, ['clientOptions' => '"foo"']);
+
+        $this->expectExceptionObject(
+            new CacheWarmup\Exception\OptionsAreMalformed('"foo"'),
+        );
+
+        $this->subject->getClientOptions();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getClientOptionsReturnsConfiguredClientOptions(): void
+    {
+        $this->extensionConfiguration->set(Src\Extension::KEY, ['clientOptions' => '{"foo":"baz"}']);
+
+        self::assertSame(['foo' => 'baz'], $this->subject->getClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
     public function getLimitReturnsDefaultLimitIfNoLimitIsConfigured(): void
     {
         $this->extensionConfiguration->set(Src\Extension::KEY);

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -19,6 +19,9 @@ verboseCrawlerOptions =
 # cat=parser/options/10; type=string; label=XML parser options (JSON-encoded string):Provide options for the XML parser to parse XML sitemaps. Example: {"request_options": {"auth": ["username", "password"]}}
 parserOptions =
 
+# cat=client/options/10; type=string; label=HTTP client options (JSON-encoded string):Provide options for the HTTP client to use for crawler and parser. Example: {"auth": ["username", "password"]}
+clientOptions =
+
 # cat=options/input/10; type=int+; label=Crawl limit:Define maximum number of pages to crawl in one iteration. Set to "0" to disable the limit.
 limit = 250
 


### PR DESCRIPTION
This PR introduces a new extension configuration `clientOptions`. It can be used to configure the global client instance used in crawlers and the XML parser to fetch external content.

> [!IMPORTANT]
> Existing client configuration must be migrated from `crawlerOptions:client_config`, `verboseCrawlerOptions:client_config` and `parserClientOptions` to `clientOptions`. Read more in the documentation.