### PR TITLE
[TASK] Use ViewFactory in TYPO3 v13 to create view

### DIFF
--- a/Classes/View/TemplateRenderer.php
+++ b/Classes/View/TemplateRenderer.php
@@ -47,9 +47,21 @@ final readonly class TemplateRenderer
      */
     public function render(string $templatePath, array $variables = []): string
     {
-        // @todo Migrate to ViewFactoryInterface::create() once support for TYPO3 v12 is dropped
-        /* @phpstan-ignore classConstant.deprecatedClass */
-        $view = Core\Utility\GeneralUtility::makeInstance(Fluid\View\StandaloneView::class, $this->renderingContext);
+        if ((new Core\Information\Typo3Version())->getMajorVersion() >= 13) {
+            $templatePaths = $this->renderingContext->getTemplatePaths();
+            $data = new Core\View\ViewFactoryData(
+                templateRootPaths: $templatePaths->getTemplateRootPaths(),
+                partialRootPaths: $templatePaths->getPartialRootPaths(),
+                layoutRootPaths: $templatePaths->getLayoutRootPaths(),
+            );
+            $viewFactory = Core\Utility\GeneralUtility::makeInstance(Core\View\ViewFactoryInterface::class);
+            $view = $viewFactory->create($data);
+        } else {
+            // @todo Remove once support for TYPO3 v12 is dropped
+            /* @phpstan-ignore classConstant.deprecatedClass */
+            $view = Core\Utility\GeneralUtility::makeInstance(Fluid\View\StandaloneView::class, $this->renderingContext);
+        }
+
         $view->assignMultiple($variables);
 
         return $view->render($templatePath);


### PR DESCRIPTION
This PR migrates the template rendering in `TemplateRenderer` to use the new `ViewFactory` in TYPO3 v13. The old behavior is kept for TYPO3 v12.