### PR TITLE
[BUGFIX] Allow custom crawling strategies on command line

### DIFF
--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -247,7 +247,7 @@ HELP
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
         // Initialize sub command
-        $subCommand = new CacheWarmup\Command\CacheWarmupCommand($this->eventDispatcher);
+        $subCommand = new CacheWarmup\Command\CacheWarmupCommand($this->eventDispatcher, $this->crawlingStrategyFactory);
         $subCommand->setApplication($this->getApplication() ?? new Console\Application());
 
         // Initialize sub command input

--- a/Classes/DependencyInjection/CrawlingStrategyCompilerPass.php
+++ b/Classes/DependencyInjection/CrawlingStrategyCompilerPass.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\DependencyInjection;
+
+use EliasHaeussler\CacheWarmup;
+use Symfony\Component\DependencyInjection;
+
+/**
+ * CrawlingStrategyCompilerPass
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class CrawlingStrategyCompilerPass implements DependencyInjection\Compiler\CompilerPassInterface
+{
+    public const TAG_NAME = 'warming.crawling_strategy';
+
+    public function process(DependencyInjection\ContainerBuilder $container): void
+    {
+        try {
+            $factory = $container->getDefinition(CacheWarmup\Crawler\Strategy\CrawlingStrategyFactory::class);
+        } catch (DependencyInjection\Exception\ServiceNotFoundException) {
+            return;
+        }
+
+        $strategies = [];
+
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
+            $strategies[] = $container->getDefinition($id)->getClass() ?? $id;
+        }
+
+        $factory->setArgument('$strategies', $strategies);
+    }
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\DependencyInjection;
+
+use EliasHaeussler\CacheWarmup;
+use Symfony\Component\DependencyInjection;
+
+return static function (DependencyInjection\ContainerBuilder $container): void {
+    $container->addCompilerPass(new CrawlingStrategyCompilerPass());
+    $container->registerForAutoconfiguration(CacheWarmup\Crawler\Strategy\CrawlingStrategy::class)
+        ->addTag(CrawlingStrategyCompilerPass::TAG_NAME)
+    ;
+};

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -55,4 +55,7 @@ services:
     # Must be public for use with GU::mI in Configuration class to avoid circular dependencies
     public: true
   EliasHaeussler\CacheWarmup\Crawler\Strategy\CrawlingStrategyFactory:
+  EliasHaeussler\CacheWarmup\Crawler\Strategy\SortByChangeFrequencyStrategy:
+  EliasHaeussler\CacheWarmup\Crawler\Strategy\SortByLastModificationDateStrategy:
+  EliasHaeussler\CacheWarmup\Crawler\Strategy\SortByPriorityStrategy:
   EliasHaeussler\CacheWarmup\DependencyInjection\ContainerFactory:

--- a/Resources/Private/Libs/Build/composer.json
+++ b/Resources/Private/Libs/Build/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"cuyz/valinor": "1.16.1",
-		"eliashaeussler/cache-warmup": "4.1.0",
+		"eliashaeussler/cache-warmup": "4.2.0",
 		"eliashaeussler/sse": "1.1.1"
 	},
 	"conflict": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0",
 		"ext-json": "*",
 		"cuyz/valinor": "^1.14.1",
-		"eliashaeussler/cache-warmup": "^4.0",
+		"eliashaeussler/cache-warmup": "^4.2",
 		"eliashaeussler/sse": "^1.0.1",
 		"eliashaeussler/typo3-sitemap-locator": "^0.1.0",
 		"guzzlehttp/guzzle": "^7.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e667042e0b02b3cf9469d88f85c5b7f",
+    "content-hash": "c3846abe6827d635b803a6667bb06619",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -784,16 +784,16 @@
         },
         {
             "name": "eliashaeussler/cache-warmup",
-            "version": "4.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/eliashaeussler/cache-warmup.git",
-                "reference": "b8016dc86ee510d449c3c4967765905b8a289a02"
+                "reference": "a4c39fa15c782aa030634343a2023edae3d1d281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eliashaeussler/cache-warmup/zipball/b8016dc86ee510d449c3c4967765905b8a289a02",
-                "reference": "b8016dc86ee510d449c3c4967765905b8a289a02",
+                "url": "https://api.github.com/repos/eliashaeussler/cache-warmup/zipball/a4c39fa15c782aa030634343a2023edae3d1d281",
+                "reference": "a4c39fa15c782aa030634343a2023edae3d1d281",
                 "shasum": ""
             },
             "require": {
@@ -860,9 +860,9 @@
             "homepage": "https://cache-warmup.dev/",
             "support": {
                 "issues": "https://github.com/eliashaeussler/cache-warmup/issues",
-                "source": "https://github.com/eliashaeussler/cache-warmup/tree/4.1.0"
+                "source": "https://github.com/eliashaeussler/cache-warmup/tree/4.2.0"
             },
-            "time": "2025-02-25T15:31:53+00:00"
+            "time": "2025-06-01T19:35:40+00:00"
         },
         {
             "name": "eliashaeussler/sse",


### PR DESCRIPTION
This PR fixes a behavior in `warming:cachewarmup` command which made it impossible to use custom crawling strategies on the command line.

Resolves: #787