### PR TITLE
[BUGFIX] Assure vendor libraries are loaded early in classic mode

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,8 +73,6 @@ jobs:
         run: |
           composer install -d Resources/Private/Libs/Build
           composer global exec phar-composer build Resources/Private/Libs/Build Resources/Private/Libs/vendors.phar
-      - name: Include PHAR file
-        run: echo "\\EliasHaeussler\\Typo3Warming\\Extension::loadVendorLibraries();" >> ext_localconf.php
 
       # Release
       - name: Publish to TER

--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -131,23 +131,4 @@ module.tx_warming {
     {
         $GLOBALS['TYPO3_CONF_VARS']['BE']['stylesheets'][self::KEY] = 'EXT:warming/Resources/Public/Css';
     }
-
-    /**
-     * Load additional libraries provided by PHAR file (only to be used in non-Composer-mode).
-     *
-     * FOR USE IN ext_localconf.php AND NON-COMPOSER-MODE ONLY.
-     */
-    public static function loadVendorLibraries(): void
-    {
-        // Vendor libraries are already available in Composer mode
-        if (Core\Core\Environment::isComposerMode()) {
-            return;
-        }
-
-        $vendorPharFile = Core\Utility\GeneralUtility::getFileAbsFileName('EXT:warming/Resources/Private/Libs/vendors.phar');
-
-        if (file_exists($vendorPharFile)) {
-            require 'phar://' . $vendorPharFile . '/vendor/autoload.php';
-        }
-    }
 }

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -25,8 +25,16 @@ namespace EliasHaeussler\Typo3Warming\DependencyInjection;
 
 use EliasHaeussler\CacheWarmup;
 use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Core;
 
 return static function (DependencyInjection\ContainerBuilder $container): void {
+    $vendorPharFile = dirname(__DIR__) . '/Resources/Private/Libs/vendors.phar';
+
+    // Load additional libraries provided by PHAR file (only to be used in non-Composer-mode)
+    if (!Core\Core\Environment::isComposerMode() && file_exists($vendorPharFile)) {
+        require 'phar://' . $vendorPharFile . '/vendor/autoload.php';
+    }
+
     $container->addCompilerPass(new CrawlingStrategyCompilerPass());
     $container->registerForAutoconfiguration(CacheWarmup\Crawler\Strategy\CrawlingStrategy::class)
         ->addTag(CrawlingStrategyCompilerPass::TAG_NAME)


### PR DESCRIPTION
Additional vendor libraries must be loaded before the service container is built, otherwise Symfony won't be able to detect those external services.

Resolves: #890