### PR TITLE
[TASK] Update PHP version in github CGL workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,8 +77,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          # @todo Use PHP 8.4 once PHP-CS-Fixer supports PHP 8.4
-          php-version: 8.3
+          php-version: 8.4
           tools: composer:v2, cs2pr
           coverage: none
       - name: Setup Node


### PR DESCRIPTION
With the release of [PHP-CS-Fixer v3.8](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.80.0) you can safely bump the CGL PHP Version, I would assume.

