### PR TITLE
[BUGFIX] Ensure preview button is generated for log records

### DIFF
--- a/Configuration/TSconfig/Page.tsconfig
+++ b/Configuration/TSconfig/Page.tsconfig
@@ -1,3 +1,8 @@
 mod.web_list {
   deniedNewTables := addToList(tx_warming_domain_model_log)
 }
+
+TCEMAIN.preview.tx_warming_domain_model_log {
+  # Dummy configuration, only needed to enable preview URLs
+  useDefaultLanguageRecord = 1
+}


### PR DESCRIPTION
With https://github.com/TYPO3/typo3/commit/27c38f78d94a6b20a4d50f537b3276abc0b26caa, generation of preview buttons was hardened. We now need a dedicated TSconfig option to explicitly enable preview URL generation.