### PR TITLE
[FEATURE] Extract warmup state determination to enum

### DIFF
--- a/Classes/Enums/WarmupState.php
+++ b/Classes/Enums/WarmupState.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Warming\Enums;
 
 use EliasHaeussler\CacheWarmup;
+use EliasHaeussler\Typo3Warming\Result;
 use Psr\Log;
 
 /**
@@ -53,6 +54,26 @@ enum WarmupState: string
         }
 
         if (CacheWarmup\Log\LogLevel::satisfies(Log\LogLevel::INFO, $level)) {
+            return self::Success;
+        }
+
+        return self::Unknown;
+    }
+
+    public static function fromCacheWarmupResult(Result\CacheWarmupResult $result): self
+    {
+        $failed = \count($result->getResult()->getFailed());
+        $successful = \count($result->getResult()->getSuccessful());
+
+        if ($failed > 0 && $successful === 0) {
+            return self::Failed;
+        }
+
+        if ($failed > 0 && $successful > 0) {
+            return self::Warning;
+        }
+
+        if ($failed === 0) {
             return self::Success;
         }
 

--- a/Classes/Http/Message/Event/WarmupFinishedEvent.php
+++ b/Classes/Http/Message/Event/WarmupFinishedEvent.php
@@ -73,7 +73,7 @@ final readonly class WarmupFinishedEvent implements SSE\Event\Event
      */
     public function getData(): array
     {
-        $state = $this->determineWarmupState();
+        $state = Enums\WarmupState::fromCacheWarmupResult($this->result);
 
         $failedUrls = $this->result->getResult()->getFailed();
         $successfulUrls = $this->result->getResult()->getSuccessful();
@@ -104,26 +104,6 @@ final readonly class WarmupFinishedEvent implements SSE\Event\Event
     public function jsonSerialize(): array
     {
         return $this->getData();
-    }
-
-    private function determineWarmupState(): Enums\WarmupState
-    {
-        $failed = \count($this->result->getResult()->getFailed());
-        $successful = \count($this->result->getResult()->getSuccessful());
-
-        if ($failed > 0 && $successful === 0) {
-            return Enums\WarmupState::Failed;
-        }
-
-        if ($failed > 0 && $successful > 0) {
-            return Enums\WarmupState::Warning;
-        }
-
-        if ($failed === 0) {
-            return Enums\WarmupState::Success;
-        }
-
-        return Enums\WarmupState::Unknown;
     }
 
     /**


### PR DESCRIPTION
This PR moves the warmup state determination by a given cache warmup result from the `WarmupFinishedEvent` class to the dedicated `WarmupState` enum, making it available to others as well.