### PR TITLE
[BUGFIX] Mark cuyz/valinor 2.2.0 as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
 		"webmozart/assert": "^1.11"
 	},
 	"conflict": {
-		"cuyz/valinor": "2.1.2"
+		"cuyz/valinor": "2.1.2 || 2.2.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "524aec0e09ed76e5030c5cf342047cca",
+    "content-hash": "98f4a93da09c4f25ad3d8bf4aa0a1049",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
https://github.com/CuyZ/Valinor/issues/691 is not yet fixed. Thus, we must skip (= mark as conflicting) all new versions of `cuyz/valinor`.