### PR TITLE
[!!!][TASK] Remove BC layer for getters in Configuration class

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Warming\Configuration;
 use EliasHaeussler\CacheWarmup;
 use EliasHaeussler\Typo3Warming\Crawler;
 use EliasHaeussler\Typo3Warming\Extension;
-use EliasHaeussler\Typo3Warming\Http;
 use mteu\TypedExtConf;
 use TYPO3\CMS\Core;
 
@@ -39,7 +38,6 @@ use TYPO3\CMS\Core;
 #[TypedExtConf\Attribute\ExtensionConfig(extensionKey: Extension::KEY)]
 final class Configuration
 {
-    private Http\Message\Request\RequestOptions $requestOptions;
     private ?CacheWarmup\Crawler\CrawlerFactory $crawlerFactory = null;
 
     /**
@@ -80,49 +78,6 @@ final class Configuration
         public readonly bool $enabledInToolbar = true,
     ) {}
 
-    public function injectRequestOptions(Http\Message\Request\RequestOptions $requestOptions): void
-    {
-        $this->requestOptions = $requestOptions;
-    }
-
-    /**
-     * @param array{} $arguments
-     *
-     * @todo Remove with v5.0
-     */
-    public function __call(string $name, array $arguments): mixed
-    {
-        $propertyName = match ($name) {
-            'getCrawlerOptions' => 'crawlerOptions',
-            'getVerboseCrawlerOptions' => 'verboseCrawlerOptions',
-            'getParserOptions' => 'parserOptions',
-            'getClientOptions' => 'clientOptions',
-            'getLimit' => 'limit',
-            'getExcludePatterns' => 'excludePatterns',
-            'getStrategy' => 'crawlingStrategy',
-            'isEnabledInPageTree' => 'enabledInPageTree',
-            'getSupportedDoktypes' => 'supportedDoktypes',
-            'isEnabledInToolbar' => 'enabledInToolbar',
-            default => throw new \BadMethodCallException(
-                \sprintf('Unknown method "%s".', $name),
-                1753475960,
-            ),
-        };
-
-        trigger_error(
-            \sprintf(
-                'Method "%s::%s()" is deprecated and will be removed in v5.0. Access class property "$%s" directly.',
-                self::class,
-                $name,
-                $propertyName,
-            ),
-            E_USER_DEPRECATED,
-        );
-
-        /* @phpstan-ignore property.dynamicName */
-        return $this->{$propertyName};
-    }
-
     /**
      * @throws CacheWarmup\Exception\CrawlerDoesNotExist
      * @throws CacheWarmup\Exception\CrawlerIsInvalid
@@ -139,24 +94,6 @@ final class Configuration
     public function getVerboseCrawler(): CacheWarmup\Crawler\VerboseCrawler
     {
         return $this->getCrawlerFactory()->get($this->verboseCrawlerClass, $this->verboseCrawlerOptions);
-    }
-
-    /**
-     * @deprecated Use {@see RequestOptions::getUserAgent()} instead. Will be removed in v5.0.
-     */
-    public function getUserAgent(): string
-    {
-        trigger_error(
-            \sprintf(
-                'Method "%s()" is deprecated and will be removed in v5.0. ' .
-                'Access User-Agent header via "%s::getUserAgent()" method instead.',
-                __METHOD__,
-                Http\Message\Request\RequestOptions::class,
-            ),
-            E_USER_DEPRECATED,
-        );
-
-        return $this->requestOptions->getUserAgent();
     }
 
     private function getCrawlerFactory(): CacheWarmup\Crawler\CrawlerFactory

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -14,6 +14,17 @@ upgrading to a new major version of this extension.
     Make sure to check out the `migration guide <https://cache-warmup.dev/migration.html>`__
     of the :composer:`eliashaeussler/cache-warmup` library as well.
 
+..  _version-5.0.0:
+
+Version 5.0.0
+=============
+
+Removal of deprecated functionality
+-----------------------------------
+
+-   Several getter methods in :php:`\EliasHaeussler\Typo3Warming\Configuration\Configuration`
+    are now finally removed (see :ref:`deprecation notices <version-4.2.0>`).
+
 ..  _version-4.2.0:
 
 Version 4.2.0

--- a/Tests/Functional/Configuration/ConfigurationTest.php
+++ b/Tests/Functional/Configuration/ConfigurationTest.php
@@ -86,7 +86,6 @@ final class ConfigurationTest extends TestingFramework\Core\Functional\Functiona
             ],
             false,
         );
-        $this->subject->injectRequestOptions($this->get(Src\Http\Message\Request\RequestOptions::class));
     }
 
     #[Framework\Attributes\Test]
@@ -105,131 +104,6 @@ final class ConfigurationTest extends TestingFramework\Core\Functional\Functiona
 
         self::assertInstanceOf(Tests\Functional\Fixtures\Classes\DummyVerboseCrawler::class, $actual);
         self::assertSame(['another' => 'foo'], $actual::$options);
-    }
-
-    /**
-     * @todo Remove with v5.0
-     */
-    #[Framework\Attributes\Test]
-    public function getUserAgentTriggersDeprecationNotice(): void
-    {
-        $deprecationMessage = null;
-
-        set_error_handler(
-            static function (int $severity, string $message) use (&$deprecationMessage) {
-                $deprecationMessage = $message;
-
-                return true;
-            },
-            E_USER_DEPRECATED,
-        );
-
-        try {
-            /* @phpstan-ignore method.deprecated */
-            $this->subject->getUserAgent();
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertSame(
-            \sprintf(
-                'Method "%s::getUserAgent()" is deprecated and will be removed in v5.0. Access User-Agent header via "%s::getUserAgent()" method instead.',
-                Src\Configuration\Configuration::class,
-                Src\Http\Message\Request\RequestOptions::class,
-            ),
-            $deprecationMessage,
-        );
-    }
-
-    /**
-     * @todo Remove with v5.0
-     */
-    #[Framework\Attributes\Test]
-    public function getUserAgentReturnsCorrectlyGeneratedUserAgent(): void
-    {
-        // Silence deprecations
-        set_error_handler(
-            static fn(int $severity, string $message) => true,
-            E_USER_DEPRECATED,
-        );
-
-        if ((new Core\Information\Typo3Version())->getMajorVersion() >= 13) {
-            $expected = 'TYPO3/tx_warming_crawleref503f61d0e736e783384fd63c5ea03da19f23a4';
-        } else {
-            $expected = 'TYPO3/tx_warming_crawler2cdfe0c134f3796954daf9395c034c39b542ca57';
-        }
-
-        try {
-            /* @phpstan-ignore method.deprecated */
-            self::assertSame($expected, $this->subject->getUserAgent());
-        } finally {
-            restore_error_handler();
-        }
-    }
-
-    /**
-     * @todo Remove with v5.0
-     */
-    #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('deprecatedMethodCallTriggersDeprecationNoticeDataProvider')]
-    public function deprecatedMethodCallTriggersDeprecationNotice(string $methodName, string $expected): void
-    {
-        $deprecationMessage = null;
-
-        set_error_handler(
-            static function (int $severity, string $message) use (&$deprecationMessage) {
-                $deprecationMessage = $message;
-
-                return true;
-            },
-            E_USER_DEPRECATED,
-        );
-
-        try {
-            /* @phpstan-ignore argument.type */
-            call_user_func([$this->subject, $methodName]);
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertSame($expected, $deprecationMessage);
-    }
-
-    /**
-     * @todo Remove with v5.0
-     */
-    #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('deprecatedMethodCallReturnsPropertyValueDataProvider')]
-    public function deprecatedMethodCallReturnsPropertyValue(string $methodName, mixed $expected): void
-    {
-        // Silence deprecations
-        set_error_handler(
-            static fn(int $severity, string $message) => true,
-            E_USER_DEPRECATED,
-        );
-
-        try {
-            /* @phpstan-ignore argument.type */
-            $actual = call_user_func([$this->subject, $methodName]);
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertEquals($expected, $actual);
-    }
-
-    /**
-     * @todo Remove with v5.0
-     */
-    #[Framework\Attributes\Test]
-    public function unsupportedMethodCallThrowsException(): void
-    {
-        $this->expectExceptionObject(
-            new \BadMethodCallException('Unknown method "foo".', 1753475960),
-        );
-
-        /* @phpstan-ignore method.notFound */
-        $this->subject->foo();
     }
 
     /**


### PR DESCRIPTION
Various getter methods were deprecated with #910 and are now removed. Consumers must access the appropriate configuration options using the dedicated properties in the `Configuration` class.

Example:

```diff
 $configuration = GeneralUtility::makeInstance(Configuration::class);
-$limit = $configuration->getLimit();
+$limit = $configuration->limit;
```