### PR TITLE
[!!!][TASK] Change additional secret used to build User-Agent header

### DIFF
--- a/Classes/Http/Message/Request/RequestOptions.php
+++ b/Classes/Http/Message/Request/RequestOptions.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3Warming\Http\Message\Request;
 
-use EliasHaeussler\Typo3Warming\Configuration;
 use Symfony\Component\DependencyInjection;
 use TYPO3\CMS\Core;
 
@@ -44,7 +43,6 @@ final readonly class RequestOptions
     {
         $string = 'TYPO3/tx_warming_crawler';
 
-        // @todo Change secret to self::class in v5.0
-        return $this->hashService->appendHmac($string, Configuration\Configuration::class);
+        return $this->hashService->appendHmac($string, self::class);
     }
 }

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -25,6 +25,16 @@ Removal of deprecated functionality
 -   Several getter methods in :php:`\EliasHaeussler\Typo3Warming\Configuration\Configuration`
     are now finally removed (see :ref:`deprecation notices <version-4.2.0>`).
 
+Use of a different secret for :php:`User-Agent` header value
+------------------------------------------------------------
+
+-   The additional secret used to HMAC-hash the generated :php:`User-Agent` header value has
+    been changed.
+-   Values of the :php:`User-Agent` header are now different compared to their previous
+    representation.
+-   Make sure to adapt all places that rely on the :php:`User-Agent` header (e.g. exclusions
+    in stats software like Matomo).
+
 ..  _version-4.2.0:
 
 Version 4.2.0

--- a/Tests/Functional/EventListener/ClientOptionsListenerTest.php
+++ b/Tests/Functional/EventListener/ClientOptionsListenerTest.php
@@ -109,7 +109,7 @@ final class ClientOptionsListenerTest extends TestingFramework\Core\Functional\F
             RequestOptions::VERIFY => false,
             RequestOptions::AUTH => ['username', 'password'],
             RequestOptions::HEADERS => [
-                'User-Agent' => 'TYPO3/tx_warming_crawleref503f61d0e736e783384fd63c5ea03da19f23a4',
+                'User-Agent' => 'TYPO3/tx_warming_crawlercbca109427154aa0b126274755477f4337ecd56d',
             ],
         ];
 

--- a/Tests/Functional/Http/Message/Request/RequestOptionsTest.php
+++ b/Tests/Functional/Http/Message/Request/RequestOptionsTest.php
@@ -64,7 +64,7 @@ final class RequestOptionsTest extends TestingFramework\Core\Functional\Function
     public function getUserAgentReturnsCorrectlyGeneratedUserAgent(): void
     {
         self::assertSame(
-            'TYPO3/tx_warming_crawleref503f61d0e736e783384fd63c5ea03da19f23a4',
+            'TYPO3/tx_warming_crawlercbca109427154aa0b126274755477f4337ecd56d',
             $this->subject->getUserAgent(),
         );
     }


### PR DESCRIPTION
The additional secret used to HMAC-hash the generated `User-Agent` header value has been changed. Values of the `User-Agent` header are now different compared to their previous representation. Make sure to adapt all places that rely on the `User-Agent` header (e.g. exclusions in stats software like Matomo).