### PR TITLE
[!!!][TASK] Drop support for eliashaeussler/cache-warmup v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0",
 		"ext-json": "*",
 		"cuyz/valinor": "^2.0",
-		"eliashaeussler/cache-warmup": "^4.2 || ^5.0",
+		"eliashaeussler/cache-warmup": "^5.0",
 		"eliashaeussler/sse": "^2.0",
 		"eliashaeussler/typo3-sitemap-locator": "^0.2.0",
 		"guzzlehttp/guzzle": "^7.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d7482e133d549c307844e53671f1342",
+    "content-hash": "915c754c140342e5f7a5d618283e7e2c",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
Upgrading to v5 is easy as the breaking changes are quite limited, see https://cache-warmup.dev/migration.html#_4-x-%E2%86%92-5-x.