### PR TITLE
[BUGFIX] Assure limited permissions apply to standard backend users

### DIFF
--- a/Classes/Service/CacheWarmupService.php
+++ b/Classes/Service/CacheWarmupService.php
@@ -30,6 +30,8 @@ use EliasHaeussler\Typo3Warming\Domain;
 use EliasHaeussler\Typo3Warming\Event;
 use EliasHaeussler\Typo3Warming\Http;
 use EliasHaeussler\Typo3Warming\Result;
+use EliasHaeussler\Typo3Warming\Security;
+use EliasHaeussler\Typo3Warming\Utility;
 use EliasHaeussler\Typo3Warming\ValueObject;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\EventDispatcher;
@@ -56,6 +58,7 @@ final readonly class CacheWarmupService
         private EventDispatcher\EventDispatcherInterface $eventDispatcher,
         private Typo3SitemapLocator\Sitemap\SitemapLocator $sitemapLocator,
         private Http\Message\PageUriBuilder $pageUriBuilder,
+        private Security\WarmupPermissionGuard $warmupPermissionGuard,
     ) {
         $this->crawler = $this->configuration->getCrawler();
     }
@@ -75,6 +78,14 @@ final readonly class CacheWarmupService
         ?int $limit = null,
         ?CacheWarmup\Crawler\Strategy\CrawlingStrategy $strategy = null,
     ): Result\CacheWarmupResult {
+        $isAdmin = Utility\BackendUtility::getBackendUser()->isAdmin();
+
+        // Deny custom configuration for non-admin users
+        if (!$isAdmin) {
+            $limit = null;
+            $strategy = null;
+        }
+
         $strategy ??= $this->configuration->crawlingStrategy;
         $cacheWarmer = new CacheWarmup\CacheWarmer(
             $limit ?? $this->configuration->limit,
@@ -94,13 +105,16 @@ final readonly class CacheWarmupService
 
         foreach ($sites as $siteWarmupRequest) {
             foreach ($siteWarmupRequest->getLanguageIds() as $languageId) {
-                $siteLanguage = $siteWarmupRequest->getSite()->getLanguageById($languageId);
-                $sitemaps = $this->sitemapLocator->locateBySite($siteWarmupRequest->getSite(), $siteLanguage);
+                $site = $siteWarmupRequest->getSite();
+                $context = new Security\Context\PermissionContext($languageId);
+
+                if (!$this->warmupPermissionGuard->canWarmupCacheOfSite($site, $context)) {
+                    continue;
+                }
+
+                $sitemaps = $this->sitemapLocator->locateBySite($site, $site->getLanguageById($languageId));
                 $cacheWarmer->addSitemaps(
-                    array_map(
-                        Domain\Model\SiteAwareSitemap::fromLocatedSitemap(...),
-                        $sitemaps,
-                    ),
+                    array_map(Domain\Model\SiteAwareSitemap::fromLocatedSitemap(...), $sitemaps),
                 );
             }
         }
@@ -113,7 +127,14 @@ final readonly class CacheWarmupService
             }
 
             foreach ($languageIds as $languageId) {
-                $uri = $this->pageUriBuilder->build($pageWarmupRequest->getPage(), $languageId);
+                $context = new Security\Context\PermissionContext($languageId);
+                $pageId = $pageWarmupRequest->getPage();
+
+                if (!$this->warmupPermissionGuard->canWarmupCacheOfPage($pageId, $context)) {
+                    continue;
+                }
+
+                $uri = $this->pageUriBuilder->build($pageId, $languageId);
 
                 if ($uri !== null) {
                     $cacheWarmer->addUrl((string)$uri);

--- a/Tests/Functional/Command/WarmupCommandTest.php
+++ b/Tests/Functional/Command/WarmupCommandTest.php
@@ -148,8 +148,8 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-1', 0.5, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2', 0.7, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1', 0.5, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 1.0, origin: $originDE),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $originDE),
         ];
 
         $this->commandTester->execute([
@@ -180,8 +180,8 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-1', 0.5, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2', 0.7, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1', 0.5, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 1.0, origin: $originDE),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $originDE),
         ];
 
         $this->commandTester->execute([
@@ -368,11 +368,11 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
         );
         $expected = [
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/', 1.0, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 1.0, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $originDE),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2', 0.7, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-1', 0.5, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1', 0.5, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $originDE),
         ];
 
         $this->commandTester->execute([
@@ -427,11 +427,11 @@ final class WarmupCommandTest extends TestingFramework\Core\Functional\Functiona
         );
         $expected = [
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/', 1.0, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 1.0, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $originDE),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2', 0.7, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-1', 0.5, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1', 0.5, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $originDE),
         ];
 
         $this->commandTester->execute([

--- a/Tests/Functional/Controller/CacheWarmupLegacyControllerTest.php
+++ b/Tests/Functional/Controller/CacheWarmupLegacyControllerTest.php
@@ -95,6 +95,7 @@ final class CacheWarmupLegacyControllerTest extends TestingFramework\Core\Functi
                     [new Typo3SitemapLocator\Sitemap\Provider\DefaultProvider()],
                 ),
                 $this->get(Src\Http\Message\PageUriBuilder::class),
+                $this->get(Src\Security\WarmupPermissionGuard::class),
             ),
         );
     }

--- a/Tests/Functional/Fixtures/Files/sitemap_de.xml
+++ b/Tests/Functional/Fixtures/Files/sitemap_de.xml
@@ -2,10 +2,10 @@
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://typo3-testing.local/de/</loc>
-        <priority>1.0</priority>
+        <priority>0.5</priority>
     </url>
     <url>
         <loc>https://typo3-testing.local/de/subsite-1-l-1</loc>
-        <priority>0.5</priority>
+        <priority>1.0</priority>
     </url>
 </urlset>

--- a/Tests/Functional/Service/CacheWarmupServiceTest.php
+++ b/Tests/Functional/Service/CacheWarmupServiceTest.php
@@ -67,6 +67,7 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
     {
         parent::setUp();
 
+        $this->importCSVDataSet(\dirname(__DIR__) . '/Fixtures/Database/be_groups.csv');
         $this->importCSVDataSet(\dirname(__DIR__) . '/Fixtures/Database/be_users.csv');
         $this->importCSVDataSet(\dirname(__DIR__) . '/Fixtures/Database/pages.csv');
 
@@ -90,6 +91,7 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
                 [new Typo3SitemapLocator\Sitemap\Provider\DefaultProvider()],
             ),
             $this->get(Src\Http\Message\PageUriBuilder::class),
+            $this->get(Src\Security\WarmupPermissionGuard::class),
         );
     }
 
@@ -127,8 +129,8 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-1', 0.5, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2', 0.7, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1', 0.5, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 1.0, origin: $originDE),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $originDE),
         ];
 
         $cacheWarmupResult = new CacheWarmup\Result\CacheWarmupResult();
@@ -237,11 +239,11 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
 
         $expected = [
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/', 1.0, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 1.0, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $originDE),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2', 0.7, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-1', 0.5, origin: $originEN),
             new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1', 0.5, origin: $originEN),
-            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 0.5, origin: $originDE),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $originDE),
         ];
 
         $cacheWarmupResult = new CacheWarmup\Result\CacheWarmupResult();
@@ -261,6 +263,174 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
 
         self::assertEquals(new Src\Result\CacheWarmupResult($cacheWarmupResult), $actual);
         self::assertEquals($expected, Tests\Functional\Fixtures\Classes\DummyCrawler::$crawledUrls);
+    }
+
+    #[Framework\Attributes\Test]
+    public function warmupDeniesCustomLimitAndStrategyForNonAdminUsers(): void
+    {
+        // Set up backend user
+        $backendUser = $this->setUpBackendUser(2);
+        $GLOBALS['LANG'] = $this->get(Core\Localization\LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $this->mockSitemapResponse('de');
+
+        $origin = new Src\Domain\Model\SiteAwareSitemap(
+            new Core\Http\Uri('https://typo3-testing.local/de/sitemap.xml'),
+            $this->site,
+            $this->site->getLanguageById(1),
+        );
+
+        $expected = [
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $origin),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $origin),
+        ];
+
+        $cacheWarmupResult = new CacheWarmup\Result\CacheWarmupResult();
+
+        foreach ($expected as $url) {
+            $cacheWarmupResult->addResult(
+                CacheWarmup\Result\CrawlingResult::createSuccessful($url),
+            );
+        }
+
+        $actual = $this->subject->warmup(
+            sites: [
+                new Src\ValueObject\Request\SiteWarmupRequest($this->site, [1]),
+            ],
+            limit: 1,
+            strategy: new CacheWarmup\Crawler\Strategy\SortByPriorityStrategy(),
+        );
+
+        self::assertEquals(new Src\Result\CacheWarmupResult($cacheWarmupResult), $actual);
+        self::assertEquals($expected, Tests\Functional\Fixtures\Classes\DummyCrawler::$crawledUrls);
+    }
+
+    #[Framework\Attributes\Test]
+    public function warmupDeniesWarmingOfInaccessibleSites(): void
+    {
+        // Set up backend user
+        $backendUser = $this->setUpBackendUser(2);
+        $GLOBALS['LANG'] = $this->get(Core\Localization\LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        // Second site
+        $inaccessibleSite = $this->createSite('https://typo3-testing.local/foo/', 'test-site-2');
+        $this->mockSitemapResponse('de_2');
+
+        // Force cache recreation after second site was created
+        $this->get(Core\Site\SiteFinder::class)->getAllSites(false);
+
+        $expected = new Src\Result\CacheWarmupResult(new CacheWarmup\Result\CacheWarmupResult());
+
+        $actual = $this->subject->warmup(
+            sites: [
+                new Src\ValueObject\Request\SiteWarmupRequest($inaccessibleSite, [1]),
+            ],
+            limit: 1,
+            strategy: new CacheWarmup\Crawler\Strategy\SortByPriorityStrategy(),
+        );
+
+        self::assertEquals($expected, $actual);
+        self::assertSame([], Tests\Functional\Fixtures\Classes\DummyCrawler::$crawledUrls);
+    }
+
+    #[Framework\Attributes\Test]
+    public function warmupDeniesWarmingOfInaccessibleSiteLanguages(): void
+    {
+        // Set up backend user
+        $backendUser = $this->setUpBackendUser(2);
+        $GLOBALS['LANG'] = $this->get(Core\Localization\LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $this->mockSitemapResponse('de');
+
+        $origin = new Src\Domain\Model\SiteAwareSitemap(
+            new Core\Http\Uri('https://typo3-testing.local/de/sitemap.xml'),
+            $this->site,
+            $this->site->getLanguageById(1),
+        );
+
+        $expected = [
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/', 0.5, origin: $origin),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/de/subsite-1-l-1', 1.0, origin: $origin),
+        ];
+
+        $cacheWarmupResult = new CacheWarmup\Result\CacheWarmupResult();
+
+        foreach ($expected as $url) {
+            $cacheWarmupResult->addResult(
+                CacheWarmup\Result\CrawlingResult::createSuccessful($url),
+            );
+        }
+
+        $actual = $this->subject->warmup(
+            sites: [
+                new Src\ValueObject\Request\SiteWarmupRequest($this->site, [0, 1]),
+            ],
+            limit: 1,
+            strategy: new CacheWarmup\Crawler\Strategy\SortByPriorityStrategy(),
+        );
+
+        self::assertEquals(new Src\Result\CacheWarmupResult($cacheWarmupResult), $actual);
+        self::assertEquals($expected, Tests\Functional\Fixtures\Classes\DummyCrawler::$crawledUrls);
+    }
+
+    #[Framework\Attributes\Test]
+    public function warmupDeniesWarmingOfInaccessiblePages(): void
+    {
+        // Set up backend user
+        $backendUser = $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = $this->get(Core\Localization\LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $expected = [
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/'),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2'),
+            new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1'),
+        ];
+
+        $cacheWarmupResult = new CacheWarmup\Result\CacheWarmupResult();
+
+        foreach ($expected as $url) {
+            $cacheWarmupResult->addResult(
+                CacheWarmup\Result\CrawlingResult::createSuccessful($url),
+            );
+        }
+
+        $actual = $this->subject->warmup(
+            pages: [
+                new Src\ValueObject\Request\PageWarmupRequest(1),
+                new Src\ValueObject\Request\PageWarmupRequest(2),
+                new Src\ValueObject\Request\PageWarmupRequest(3),
+                new Src\ValueObject\Request\PageWarmupRequest(4),
+            ],
+        );
+
+        self::assertEquals(new Src\Result\CacheWarmupResult($cacheWarmupResult), $actual);
+        self::assertEquals($expected, Tests\Functional\Fixtures\Classes\DummyCrawler::$crawledUrls);
+    }
+
+    #[Framework\Attributes\Test]
+    public function warmupDeniesWarmingOfInaccessiblePageLanguages(): void
+    {
+        // Set up backend user
+        $backendUser = $this->setUpBackendUser(1);
+        $GLOBALS['LANG'] = $this->get(Core\Localization\LanguageServiceFactory::class)->createFromUserPreferences($backendUser);
+
+        $expected = new CacheWarmup\Sitemap\Url('https://typo3-testing.local/subsite-2/subsite-2-1');
+
+        $cacheWarmupResult = new CacheWarmup\Result\CacheWarmupResult();
+        $cacheWarmupResult->addResult(
+            CacheWarmup\Result\CrawlingResult::createSuccessful($expected),
+        );
+
+        $actual = $this->subject->warmup(
+            pages: [
+                new Src\ValueObject\Request\PageWarmupRequest(1, [1]),
+                new Src\ValueObject\Request\PageWarmupRequest(3, [1]),
+                new Src\ValueObject\Request\PageWarmupRequest(4, [0]),
+            ],
+        );
+
+        self::assertEquals(new Src\Result\CacheWarmupResult($cacheWarmupResult), $actual);
+        self::assertEquals([$expected], Tests\Functional\Fixtures\Classes\DummyCrawler::$crawledUrls);
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
Fixes an authorization flaw for site languages to be warmed up. In addition, explicitly limits the "limit" and "strategy" options to admin users only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warmup now respects access permissions and skips warming caches for sites, site-languages, pages or page-languages the caller is not allowed to warm.

* **Changed Behavior**
  * Non-admin backend users can no longer override cache warmup limit and strategy; configured defaults are used.

* **Tests**
  * Functional tests and fixtures updated to cover permission behavior and adjusted sitemap priority expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->