### PR TITLE
[BUGFIX] Circumvent broken language handling on pid=0 (TYPO3 v14)

### DIFF
--- a/Tests/Acceptance/Backend/Form/FormDataProvider/SimulateLogPageRowCest.php
+++ b/Tests/Acceptance/Backend/Form/FormDataProvider/SimulateLogPageRowCest.php
@@ -49,12 +49,8 @@ final class SimulateLogPageRowCest
         $I->loginAs('admin');
         $I->openModule($recordsModuleIdentifier);
 
-        $numberOfLogs = $I->grabNumRecords(Src\Domain\Model\Log::TABLE_NAME);
-        $randomLogNumber = random_int(1, $numberOfLogs);
-        $selector = sprintf('tr[data-table="tx_warming_domain_model_log"]:nth-child(%d) td.col-title a', $randomLogNumber);
-
-        $I->scrollToElementInModule($selector);
-        $I->click($selector);
+        $I->scrollToElementInModule(Tests\Acceptance\Support\Enums\Selectors::DatabaseRecordsTableItem);
+        $I->click(Tests\Acceptance\Support\Enums\Selectors::DatabaseRecordsTableItem);
 
         $recordUid = $I->grabFromCurrentUrl('~edit%5Btx_warming_domain_model_log%5D%5B(\\d+)%5D=edit~');
 

--- a/Tests/Acceptance/Support/Enums/Selectors.php
+++ b/Tests/Acceptance/Support/Enums/Selectors.php
@@ -43,6 +43,7 @@ enum Selectors: string
     public const ContextMenu = '.context-menu';
     public const ContextMenuGroup = '.context-menu .context-menu-group';
     public const ContextMenuSubmenu = '.context-menu[data-contextmenu-parent]';
+    public const DatabaseRecordsTableItem = 'tr[data-table="tx_warming_domain_model_log"]:first-child td.col-title a';
     public const ExtensionConfigurationModalCollapseHeader = '#heading-warming';
     public const InformationModal = 'typo3-backend-modal[content^="/typo3/record/info"]';
     public const ModalHeader = '.tx-warming-modal-header';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by refactoring log table selection logic to use predefined selectors instead of dynamic random row targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->