### PR TITLE
[BUGFIX] Assure the original request id is attached to warming log records

### DIFF
--- a/Classes/Crawler/LoggingCrawlerTrait.php
+++ b/Classes/Crawler/LoggingCrawlerTrait.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3Warming\Crawler;
 
-use EliasHaeussler\CacheWarmup;
 use EliasHaeussler\SSE;
+use EliasHaeussler\Typo3Warming\Http;
 use Psr\Log;
 use TYPO3\CMS\Core;
 
@@ -38,31 +38,25 @@ trait LoggingCrawlerTrait
 {
     private ?Log\LoggerInterface $logger = null;
 
-    private function createLogHandler(): CacheWarmup\Http\Message\Handler\LogHandler
+    private function createLogHandler(): Http\Message\Handler\LogHandler
     {
         $logger = $this->logger;
+        $requestId = null;
 
         if ($logger === null) {
             $logger = $this->createLogger();
         }
 
-        // We use lowest log level because logger minimum log level is handled by the logger itself
-        return new CacheWarmup\Http\Message\Handler\LogHandler($logger, Log\LogLevel::DEBUG);
+        if ($this instanceof StreamableCrawler && $this->stream instanceof SSE\Stream\SelfEmittingEventStream) {
+            $requestId = $this->stream->getId();
+        }
+
+        return new Http\Message\Handler\LogHandler($logger, $requestId);
     }
 
     private function createLogger(): Log\LoggerInterface
     {
-        if ($this instanceof StreamableCrawler && $this->stream instanceof SSE\Stream\SelfEmittingEventStream) {
-            $requestId = $this->stream->getId();
-            // We avoid calling GeneralUtility::makeInstance() here
-            // since LogManager is a singleton and we would not be
-            // able to create a new instance of it.
-            $logManager = new Core\Log\LogManager($requestId);
-        } else {
-            $logManager = Core\Utility\GeneralUtility::makeInstance(Core\Log\LogManager::class);
-        }
-
-        return $logManager->getLogger(static::class);
+        return Core\Utility\GeneralUtility::makeInstance(Core\Log\LogManager::class)->getLogger(static::class);
     }
 
     public function setLogger(Log\LoggerInterface $logger): void

--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3Warming;
 
+use Psr\Log\LogLevel;
 use TYPO3\CMS\Backend;
 use TYPO3\CMS\Core;
 
@@ -111,5 +112,17 @@ module.tx_warming {
     public static function registerCustomStyles(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['BE']['stylesheets'][self::KEY] = 'EXT:warming/Resources/Public/Css';
+    }
+
+    /**
+     * Register custom log processors.
+     *
+     * FOR USE IN ext_localconf.php ONLY.
+     */
+    public static function registerLogProcessors(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['LOG']['EliasHaeussler']['Typo3Warming']['processorConfiguration'][LogLevel::DEBUG][
+            Log\Processor\RequestIdProcessor::class
+        ] = [];
     }
 }

--- a/Classes/Http/Message/Handler/LogHandler.php
+++ b/Classes/Http/Message/Handler/LogHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\Http\Message\Handler;
+
+use EliasHaeussler\CacheWarmup;
+use Psr\Http\Message;
+use Psr\Log;
+
+/**
+ * LogHandler
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class LogHandler implements CacheWarmup\Http\Message\Handler\ResponseHandler
+{
+    public function __construct(
+        private Log\LoggerInterface $logger,
+        private ?string $requestId = null,
+    ) {}
+
+    public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void
+    {
+        $this->logger->info(
+            'URL {url} was successfully crawled (status code: {status_code}).',
+            [
+                'url' => $uri,
+                'status_code' => $response->getStatusCode(),
+                'request_id' => $this->requestId,
+            ],
+        );
+    }
+
+    public function onFailure(\Throwable $exception, Message\UriInterface $uri): void
+    {
+        $this->logger->error(
+            'Error while crawling URL {url} (exception: {exception}).',
+            [
+                'url' => $uri,
+                'exception' => $exception,
+                'request_id' => $this->requestId,
+            ],
+        );
+    }
+}

--- a/Classes/Log/Processor/RequestIdProcessor.php
+++ b/Classes/Log/Processor/RequestIdProcessor.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\Log\Processor;
+
+use TYPO3\CMS\Core;
+
+/**
+ * RequestIdProcessor
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class RequestIdProcessor implements Core\Log\Processor\ProcessorInterface
+{
+    public function processLogRecord(Core\Log\LogRecord $logRecord): Core\Log\LogRecord
+    {
+        $requestId = $logRecord->getData()['request_id'] ?? null;
+
+        // Override request id with original request id, if available (this reflects the
+        // "default" state where cache warmup is requested from backend context, where
+        // a new request id is generated and attached to the warmup request object
+        if (is_string($requestId)) {
+            $logRecord->setRequestId($requestId);
+        }
+
+        return $logRecord;
+    }
+}

--- a/Tests/Unit/Http/Message/Handler/LogHandlerTest.php
+++ b/Tests/Unit/Http/Message/Handler/LogHandlerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\Tests\Unit\Http\Message\Handler;
+
+use EliasHaeussler\TransientLogger;
+use EliasHaeussler\Typo3Warming as Src;
+use PHPUnit\Framework;
+use TYPO3\CMS\Core;
+use TYPO3\TestingFramework;
+
+/**
+ * LogHandlerTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Http\Message\Handler\LogHandler::class)]
+final class LogHandlerTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private TransientLogger\TransientLogger $logger;
+    private Src\Http\Message\Handler\LogHandler $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = new TransientLogger\TransientLogger();
+        $this->subject = new Src\Http\Message\Handler\LogHandler($this->logger, 'baz');
+    }
+
+    #[Framework\Attributes\Test]
+    public function onSuccessLogsInfoAndAttachesRequestId(): void
+    {
+        $response = new Core\Http\Response();
+        $uri = new Core\Http\Uri('https://typo3-testing.local/');
+
+        $expected = new TransientLogger\Log\LogRecord(
+            TransientLogger\Log\LogLevel::Info,
+            'URL {url} was successfully crawled (status code: {status_code}).',
+            [
+                'url' => $uri,
+                'status_code' => 200,
+                'request_id' => 'baz',
+            ],
+        );
+
+        $this->subject->onSuccess($response, $uri);
+
+        self::assertEquals([$expected], $this->logger->getAll());
+    }
+
+    #[Framework\Attributes\Test]
+    public function onFailureLogsErrorAndAttachesRequestId(): void
+    {
+        $exception = new \Exception('Something went wrong');
+        $uri = new Core\Http\Uri('https://typo3-testing.local/');
+
+        $expected = new TransientLogger\Log\LogRecord(
+            TransientLogger\Log\LogLevel::Error,
+            'Error while crawling URL {url} (exception: {exception}).',
+            [
+                'url' => $uri,
+                'exception' => $exception,
+                'request_id' => 'baz',
+            ],
+        );
+
+        $this->subject->onFailure($exception, $uri);
+
+        self::assertEquals([$expected], $this->logger->getAll());
+    }
+}

--- a/Tests/Unit/Log/Processor/RequestIdProcessorTest.php
+++ b/Tests/Unit/Log/Processor/RequestIdProcessorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "warming".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Warming\Tests\Unit\Log\Processor;
+
+use EliasHaeussler\Typo3Warming as Src;
+use PHPUnit\Framework;
+use Psr\Log;
+use TYPO3\CMS\Core;
+use TYPO3\TestingFramework;
+
+/**
+ * RequestIdProcessorTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Log\Processor\RequestIdProcessor::class)]
+final class RequestIdProcessorTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Core\Log\LogRecord $logRecord;
+    private Src\Log\Processor\RequestIdProcessor $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logRecord = new Core\Log\LogRecord(
+            'test',
+            Log\LogLevel::ERROR,
+            'Something went wrong.',
+            [],
+            'foo',
+        );
+        $this->subject = new Src\Log\Processor\RequestIdProcessor();
+    }
+
+    #[Framework\Attributes\Test]
+    public function processLogRecordDoesNothingIfRequestIdIsMissingInRecordData(): void
+    {
+        $actual = $this->subject->processLogRecord($this->logRecord);
+
+        self::assertSame('foo', $actual->getRequestId());
+    }
+
+    #[Framework\Attributes\Test]
+    public function processLogRecordOverwritesRequestIdFromRecordData(): void
+    {
+        $this->logRecord->setData(['request_id' => 'baz']);
+
+        $actual = $this->subject->processLogRecord($this->logRecord);
+
+        self::assertSame('baz', $actual->getRequestId());
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,3 +23,4 @@
 \EliasHaeussler\Typo3Warming\Extension::registerFormDataProviders();
 \EliasHaeussler\Typo3Warming\Extension::registerTypoScript();
 \EliasHaeussler\Typo3Warming\Extension::registerCustomStyles();
+\EliasHaeussler\Typo3Warming\Extension::registerLogProcessors();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request ID tracking added to crawler logging for improved traceability
  * Enhanced HTTP logging with detailed success and failure entries (URL, status, exception, request ID)
  * Extension now registers a request-id log processor during initialization

* **Tests**
  * Added unit tests for the log handler (success and failure logging)
  * Added unit tests for the request-id log processor behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->