### PR TITLE
[TASK] Deprecate `CacheWarmupService::getCrawler()` method

### DIFF
--- a/Classes/Service/CacheWarmupService.php
+++ b/Classes/Service/CacheWarmupService.php
@@ -157,8 +157,21 @@ final readonly class CacheWarmupService
         return $result;
     }
 
+    /**
+     * @deprecated since v5.3, use {@see Configuration\Configuration::getCrawler()} instead.
+     * @todo Remove with EXT:warming v6.0
+     */
     public function getCrawler(): CacheWarmup\Crawler\Crawler
     {
+        \trigger_error(
+            \sprintf(
+                'Accessing the current crawler using %s() is deprecated since v5.3 and will be removed in v6.0. Use %s::getCrawler() instead.',
+                __METHOD__,
+                Configuration\Configuration::class,
+            ),
+            E_USER_DEPRECATED,
+        );
+
         return $this->crawler;
     }
 }

--- a/Tests/Functional/Service/CacheWarmupServiceTest.php
+++ b/Tests/Functional/Service/CacheWarmupServiceTest.php
@@ -507,11 +507,24 @@ final class CacheWarmupServiceTest extends TestingFramework\Core\Functional\Func
         self::assertSame(50, $actual->getCacheWarmer()->getLimit());
     }
 
+    /**
+     * @todo Remove with EXT:warming v6.0
+     */
     #[Framework\Attributes\Test]
+    #[Framework\Attributes\IgnoreDeprecations]
     public function getCrawlerReturnsGloballyConfiguredCrawler(): void
     {
+        $this->expectUserDeprecationMessage(
+            sprintf(
+                'Accessing the current crawler using %s::getCrawler() is deprecated since v5.3 and will be removed in v6.0. Use %s::getCrawler() instead.',
+                Src\Service\CacheWarmupService::class,
+                Src\Configuration\Configuration::class,
+            ),
+        );
+
         self::assertInstanceOf(
             Tests\Functional\Fixtures\Classes\DummyCrawler::class,
+            /* @phpstan-ignore method.deprecated */
             $this->subject->getCrawler(),
         );
     }


### PR DESCRIPTION
Use `Configuration::getCrawler()` instead.
